### PR TITLE
Enable remote build caching

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -17,4 +17,6 @@ jobs:
       - name: Build with Maven
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+          GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_SOLUTIONS_CACHE_USERNAME }}
+          GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_SOLUTIONS_CACHE_PASSWORD }}
         run: ./mvnw clean verify -B

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -17,5 +17,16 @@
     <local>
       <enabled>true</enabled>
     </local>
+    <remote>
+      <server>
+        <url>https://ge.solutions-team.gradle.com/cache/</url>
+        <allowUntrusted>false</allowUntrusted>
+        <credentials>
+          <username>${env.GRADLE_ENTERPRISE_CACHE_USERNAME}</username>
+          <password>${env.GRADLE_ENTERPRISE_CACHE_PASSWORD}</password>
+        </credentials>
+      </server>
+      <storeEnabled>#{isTrue(env['GITHUB_ACTIONS'])}</storeEnabled>
+    </remote>
   </buildCache>
 </gradleEnterprise>


### PR DESCRIPTION
This change enables the remote build cache for all builds. Anonymous
users have read-only build cache access, while CI has read-write.

This change also configures GitHub actions to authenticate with the
build cache.