### PR TITLE
Upgrade Github actions/checkout to v3

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
Deprecation warnings appear when running actions/checkout@v2, this is fixed when upgrading to actions/checkout@v3