### PR TITLE
Updates to CustomGradleEnterpriseConfig commented sample code

### DIFF
--- a/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -27,7 +27,7 @@ final class CustomGradleEnterpriseConfig {
         boolean isCiServer = System.getenv().containsKey("CI");
 
         buildScans.publishAlways();
-        buildScans.setCaptureGoalInputFiles(true);
+        buildScans.capture(capture -> capture.setGoalInputFiles(true));
         buildScans.setUploadInBackground(!isCiServer);
 
         */

--- a/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -44,7 +44,6 @@ final class CustomGradleEnterpriseConfig {
 
         // Only permit store operations to the remote build cache for CI builds
         // Local builds will only read from the remote build cache
-        buildCache.getRemote().getServer().setUrl(URI.create("https://enterprise-samples.gradle.com/cache/"));
         buildCache.getRemote().setEnabled(true);
         buildCache.getRemote().setStoreEnabled(isCiServer);
 


### PR DESCRIPTION
The commented sample code in CustomGradleEnterpriseConfig contains two lines that are outdated. This change:

- Uses the new capture API recommended as of Common Custom User Data Maven Extension 1.11
- Removes the URL configuration for the remote build cache in favor of the default built-in build cache node configuration