### PR TITLE
Expose CiUtils#isCi for usage outside of the extension

### DIFF
--- a/src/main/java/com/gradle/CiUtils.java
+++ b/src/main/java/com/gradle/CiUtils.java
@@ -1,11 +1,11 @@
 package com.gradle;
 
-final class CiUtils {
+public final class CiUtils {
 
     private CiUtils() {
     }
 
-    static boolean isCi() {
+    public static boolean isCi() {
         return isGenericCI()
                 || isJenkins()
                 || isHudson()


### PR DESCRIPTION
See https://github.com/gradle/gradle-enterprise-build-config-samples/pull/636#discussion_r1142689091 for more.

This change would allow extensions that may include this extension in the classpath to reuse `isCi` for checks such background scan upload or remote scan store enabled.