### PR TITLE
Support custom links to alternate GitHub URLs

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -3,6 +3,8 @@ package com.gradle;
 import com.gradle.maven.extension.api.scan.BuildScanApi;
 import org.apache.maven.execution.MavenSession;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -227,7 +229,7 @@ final class CustomBuildScanEnhancements {
                 Optional<String> gitRepository = envVariable("GITHUB_REPOSITORY");
                 Optional<String> gitHubRunId = envVariable("GITHUB_RUN_ID");
                 if (gitHubUrl.isPresent() && gitRepository.isPresent() && gitHubRunId.isPresent()) {
-                    buildScan.link("GitHub Actions build", gitHubUrl + "/" + gitRepository.get() + "/actions/runs/" + gitHubRunId.get());
+                    buildScan.link("GitHub Actions build", gitHubUrl.get() + "/" + gitRepository.get() + "/actions/runs/" + gitHubRunId.get());
                 }
                 envVariable("GITHUB_WORKFLOW").ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI workflow", value));
@@ -313,6 +315,8 @@ final class CustomBuildScanEnhancements {
 
     private static final class CaptureGitMetadataAction implements Consumer<BuildScanApi> {
 
+        private static final Pattern GIT_REPO_URI_PATTERN = Pattern.compile("^(?:https://|(?:ssh)?.*?@)(.*?(?:github|gitlab).*?)(?:/|:[0-9]*?/|:)(.*?)(?:\\.git)?$");
+
         @Override
         public void accept(BuildScanApi buildScan) {
             if (!isGitInstalled()) {
@@ -343,22 +347,19 @@ final class CustomBuildScanEnhancements {
                 buildScan.value("Git status", gitStatus);
             }
 
-            if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
-                if (gitRepo.contains("github.com/") || gitRepo.contains("github.com:")) {
-                    Matcher matcher = Pattern.compile("(.*)github\\.com[/|:](.*)").matcher(gitRepo);
-                    if (matcher.matches()) {
-                        String rawRepoPath = matcher.group(2);
-                        String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
-                        buildScan.link("Github source", "https://github.com/" + repoPath + "/tree/" + gitCommitId);
+            Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL");
+            Optional<String> gitRepository = envVariable("GITHUB_REPOSITORY");
+            if (gitHubUrl.isPresent() && gitRepository.isPresent() && isNotEmpty(gitCommitId)) {
+                buildScan.link("GitHub source", gitHubUrl.get() + "/" + gitRepository.get() + "/tree/" + gitCommitId);
+            } else if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
+                Optional<URI> webRepoUri = toWebRepoUri(gitRepo);
+                webRepoUri.ifPresent(uri -> {
+                    if (uri.getHost().contains("github")) {
+                        buildScan.link("GitHub source", uri + "/tree/" + gitCommitId);
+                    } else if (uri.getHost().contains("gitlab")) {
+                        buildScan.link("GitLab source", uri + "/-/commit/" + gitCommitId);
                     }
-                } else if (gitRepo.contains("gitlab.com/") || gitRepo.contains("gitlab.com:")) {
-                    Matcher matcher = Pattern.compile("(.*)gitlab\\.com[/|:](.*)").matcher(gitRepo);
-                    if (matcher.matches()) {
-                        String rawRepoPath = matcher.group(2);
-                        String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
-                        buildScan.link("GitLab Source", "https://gitlab.com/" + repoPath + "/-/commit/" + gitCommitId);
-                    }
-                }
+                });
             }
         }
 
@@ -386,6 +387,25 @@ final class CustomBuildScanEnhancements {
             return gitCommand.get();
         }
 
+        private Optional<URI> toWebRepoUri(String gitRepoUri) {
+            Matcher matcher = GIT_REPO_URI_PATTERN.matcher(gitRepoUri);
+            if (matcher.matches()) {
+                String scheme = "https";
+                String host = matcher.group(1);
+                String path = matcher.group(2).startsWith("/") ? matcher.group(2) : "/" + matcher.group(2);
+                return toUri(scheme, host, path);
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        private Optional<URI> toUri(String scheme, String host, String path) {
+            try {
+                return Optional.of(new URI(scheme, host, path, null));
+            } catch (URISyntaxException e) {
+                return Optional.empty();
+            }
+        }
     }
 
     private void captureSkipTestsFlags() {

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -223,10 +223,11 @@ final class CustomBuildScanEnhancements {
             }
 
             if (isGitHubActions()) {
-                Optional<String> gitHubRepository = envVariable("GITHUB_REPOSITORY");
+                Optional<String> gitHubUrl = envVariable("GITHUB_SERVER_URL");
+                Optional<String> gitRepository = envVariable("GITHUB_REPOSITORY");
                 Optional<String> gitHubRunId = envVariable("GITHUB_RUN_ID");
-                if (gitHubRepository.isPresent() && gitHubRunId.isPresent()) {
-                    buildScan.link("GitHub Actions build", "https://github.com/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
+                if (gitHubUrl.isPresent() && gitRepository.isPresent() && gitHubRunId.isPresent()) {
+                    buildScan.link("GitHub Actions build", gitHubUrl + "/" + gitRepository.get() + "/actions/runs/" + gitHubRunId.get());
                 }
                 envVariable("GITHUB_WORKFLOW").ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI workflow", value));


### PR DESCRIPTION
Applies the same changes that were applied to the Gradle plugin in gradle/common-custom-user-data-gradle-plugin#150

When creating links to GitHub Actions builds, the plugin now references the environment variable GITHUB_SERVER_URL instead of hardcoding https://github.com/.

When creating build scan links to the remote repository, the plugin now uses a regex to parse out the correct url instead of hardcoding https://github.com/ or https://gitlab.com/.

### Tests
1. Published plugin to maven local and resolved it using version `1.12-SNAPSHOT` ([build scan - extensions](https://ge.solutions-team.gradle.com/s/eiab67l7zcht6/extensions?details=0)). Generated correct `GitHub source` link to CCUD extension repository ([build scan - summary](https://ge.solutions-team.gradle.com/s/eiab67l7zcht6)).
2. GE `common-custom-user-data-maven-extension` functional tests pass when run locally ([build scan](https://e.grdev.net/s/k67a2yh3pblhg/tests/overview))
```
./gradlew :common-custom-user-data-maven-extension-test-func:clean :common-custom-user-data-maven-extension-test-func:build -PcommonCustomUserDataExtensionProjectDir=/Users/tyler/projects/gradle/common-custom-user-data-maven-extension
```