### PR TITLE
Added UtilsTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
             <artifactId>ivy</artifactId>
             <version>2.5.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/gradle/UtilsTest.java
+++ b/src/test/java/com/gradle/UtilsTest.java
@@ -1,0 +1,38 @@
+package com.gradle;
+
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static com.gradle.Utils.toWebRepoUri;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UtilsTest {
+
+    @Test
+    public void toWebRepoUri_git() {
+        assertEquals(
+            URI.create("https://github.com/acme-inc/my-project"),
+            toWebRepoUri("git://github.com/acme-inc/my-project.git").get());
+        assertEquals(
+            URI.create("https://gitlab.com/acme-inc/my-project"),
+            toWebRepoUri("git://gitlab.com/acme-inc/my-project.git").get());
+        assertEquals(
+            URI.create("https://github.com/acme-inc/my-project"),
+            toWebRepoUri("git@github.com:acme-inc/my-project.git").get());
+        assertEquals(
+            URI.create("https://gitlab.com/acme-inc/my-project"),
+            toWebRepoUri("git@gitlab.com:acme-inc/my-project.git").get());
+    }
+
+    @Test
+    public void toWebRepoUri_https() {
+        assertEquals(
+            URI.create("https://github.com/acme-inc/my-project"),
+            toWebRepoUri("https://github.com/acme-inc/my-project").get());
+        assertEquals(
+            URI.create("https://gitlab.com/acme-inc/my-project"),
+            toWebRepoUri("https://gitlab.com/acme-inc/my-project").get());
+    }
+}


### PR DESCRIPTION
Added back the UtilsTest that were originally part of [PR 126 - Add buildkite support to scans](https://github.com/gradle/common-custom-user-data-maven-extension/pull/126), since now the GE Maven Extension 1.17.3 has been released and used.