### PR TITLE
Use bot-githubactions to execute combine-prs action

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -20,4 +20,4 @@ jobs:
         uses: github/combine-prs@v3.1.1
         with:
           branch_regex: ^(dependa|wrapper)bot\/.*$
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Draft: need to ensure GH_BOT_GITHUB_TOKEN secret exists in this repo before merging

GITHUB_TOKEN credential is not allowed to trigger other workflows, so checks were not running for combine-prs PRs. Using bot-githubactions credentials to create the combine-prs PR resolves this.