### PR TITLE
Collect project properties from the userProperties map

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-
+- [FIX] Project properties not collected as custom values from Maven 4.0.0-alpha-06 ([related issue](https://issues.apache.org/jira/browse/MNG-7829))

--- a/src/main/java/com/gradle/Utils.java
+++ b/src/main/java/com/gradle/Utils.java
@@ -30,7 +30,7 @@ final class Utils {
     }
 
     static Optional<String> projectProperty(MavenSession mavenSession, String name) {
-        String value = mavenSession.getSystemProperties().getProperty(name);
+        String value = mavenSession.getUserProperties().getProperty(name);
         return Optional.ofNullable(value);
     }
 


### PR DESCRIPTION
### Issue
Project properties `skipTests`, `skipITs` and `maven.test.skip` are not added as custom values by the extension when building with _Maven 4.0.0-alpha-06_ and above ([this commit](https://github.com/apache/maven/commit/a1fa3eb5346f562a745f054650eee1e84c44db30?diff=unified) changed the behavior). 

As described in the [documentation](https://maven.apache.org/ref/3.9.3/maven-embedder/cli.html) and confirmed in [the related ticket](https://issues.apache.org/jira/browse/MNG-7829), the problem is to use [session.systemProperties](https://maven.apache.org/ref/3.9.3/maven-core/apidocs/org/apache/maven/execution/MavenSession.html#getSystemProperties()) instead of [session.userProperties](https://maven.apache.org/ref/3.9.3/maven-core/apidocs/org/apache/maven/execution/MavenSession.html#getUserProperties()).

### Fix
Adjust the input Map
I have tested locally that this is valid with Maven 3.8 and 3.9