### PR TITLE
Revert detached head detection

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,2 +1,0 @@
-- [NEW] Improve tags/values in GitHub Actions `pull_request` workflows
-- [NEW] Improve tags/values in Jenkins where `GIT_BRANCH` is available


### PR DESCRIPTION
Revert detached head detection as it introduces breaking changes. Will get reapplied after a minor release.

This PR reverts the following PR #198 - Improve tags/values in Jenkins and GitHub Actions when git is in a detached HEAD state