### PR TITLE
CCUD extension configures the Develocity extension using the new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Groovy script. This is a good intermediate step before creating your own extensi
 The Common Custom User Data Maven extension checks for a `.mvn/gradle-enterprise-custom-user-data.groovy` or `.mvn/develocity-custom-user-data.groovy` Groovy script in your root project. If the file exists, it evaluates
 the script with the following bindings:
 
-- `gradleEnterprise/develocity` (type: [DevelocityAdapter](src/main/java/com/gradle/ccud/adapters/DevelocityAdapter.java)): _configure Develocity_
+- `gradleEnterprise/develocity` (type: [CoreApiAdapter](src/main/java/com/gradle/ccud/adapters/CoreApiAdapter.java)): _configure Develocity_
 - `buildScan` (type: [BuildScanApiAdapter](src/main/java/com/gradle/ccud/adapters/DevelocityAdapter.java)): _configure build scan publishing and enhance build scans_
 - `buildCache` (type: [BuildCacheApiAdapter](src/main/java/com/gradle/ccud/adapters/DevelocityAdapter.java)): _configure build cache_
 - `log` (type: [`Logger`](http://www.slf4j.org/apidocs/org/slf4j/Logger.html)): _write to the build log_

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can leverage this extension for your project in one of two ways:
 ## Applying the published extension
 
 The Common Custom User Data Maven extension is available in [Maven Central](https://search.maven.org/artifact/com.gradle/common-custom-user-data-maven-extension). This extension
-requires the [Develocity Maven extension](https://search.maven.org/artifact/com.gradle/gradle-enterprise-maven-extension) to also be applied in your build in order to have
+requires the [Develocity Maven extension](https://search.maven.org/artifact/com.gradle/develocity-maven-extension) to also be applied in your build in order to have
 an effect.
 
 In order for the Common Custom User Data Maven extension to become active, you need to register it in the `.mvn/extensions.xml` file in your root project. The `extensions.xml` file
@@ -57,7 +57,7 @@ captured and under which conditions.
 You can apply additional configuration beyond what is contributed by the Common Custom User Data Maven extension by default. The additional configuration happens in a specific
 Groovy script. This is a good intermediate step before creating your own extension.
 
-The Common Custom User Data Maven extension checks for a `.mvn/gradle-enterprise-custom-user-data.groovy` Groovy script in your root project. If the file exists, it evaluates
+The Common Custom User Data Maven extension checks for a `.mvn/gradle-enterprise-custom-user-data.groovy` or `.mvn/develocity-custom-user-data.groovy` Groovy script in your root project. If the file exists, it evaluates
 the script with the following bindings:
 
 - `gradleEnterprise` (type: [GradleEnterpriseApi](https://docs.gradle.com/enterprise/maven-extension/api/com/gradle/maven/extension/api/GradleEnterpriseApi.html)): _configure Develocity_

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can leverage this extension for your project in one of two ways:
 ## Applying the published extension
 
 The Common Custom User Data Maven extension is available in [Maven Central](https://search.maven.org/artifact/com.gradle/common-custom-user-data-maven-extension). This extension
-requires the [Develocity Maven extension](https://search.maven.org/artifact/com.gradle/develocity-maven-extension) to also be applied in your build in order to have
+requires the [Develocity Maven extension](https://search.maven.org/artifact/com.gradle/gradle-enterprise-maven-extension) to also be applied in your build in order to have
 an effect.
 
 In order for the Common Custom User Data Maven extension to become active, you need to register it in the `.mvn/extensions.xml` file in your root project. The `extensions.xml` file

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Groovy script. This is a good intermediate step before creating your own extensi
 The Common Custom User Data Maven extension checks for a `.mvn/gradle-enterprise-custom-user-data.groovy` or `.mvn/develocity-custom-user-data.groovy` Groovy script in your root project. If the file exists, it evaluates
 the script with the following bindings:
 
-- `gradleEnterprise` (type: [GradleEnterpriseApi](https://docs.gradle.com/enterprise/maven-extension/api/com/gradle/maven/extension/api/GradleEnterpriseApi.html)): _configure Develocity_
-- `buildScan` (type: [BuildScanApi](https://docs.gradle.com/enterprise/maven-extension/api/com/gradle/maven/extension/api/scan/BuildScanApi.html)): _configure build scan publishing and enhance build scans_
-- `buildCache` (type: [BuildCacheApi](https://docs.gradle.com/enterprise/maven-extension/api/com/gradle/maven/extension/api/cache/BuildCacheApi.html)): _configure build cache_
+- `gradleEnterprise/develocity` (type: [DevelocityAdapter](src/main/java/com/gradle/ccud/adapters/DevelocityAdapter.java)): _configure Develocity_
+- `buildScan` (type: [BuildScanApiAdapter](src/main/java/com/gradle/ccud/adapters/DevelocityAdapter.java)): _configure build scan publishing and enhance build scans_
+- `buildCache` (type: [BuildCacheApiAdapter](src/main/java/com/gradle/ccud/adapters/DevelocityAdapter.java)): _configure build cache_
 - `log` (type: [`Logger`](http://www.slf4j.org/apidocs/org/slf4j/Logger.html)): _write to the build log_
 - `project` (type: [`MavenProject`](https://maven.apache.org/ref/current/maven-core/apidocs/org/apache/maven/project/MavenProject.html)): _the top-level Maven project_
 - `session` (type: [`MavenSession`](https://maven.apache.org/ref/current/maven-core/apidocs/org/apache/maven/execution/MavenSession.html)): _the Maven session_

--- a/pom.xml
+++ b/pom.xml
@@ -63,16 +63,18 @@
             <version>2.2.0</version>
             <scope>provided</scope>
         </dependency>
+        <!-- exposes GradleEnterprise* interfaces -->
         <dependency>
             <groupId>com.gradle</groupId>
             <artifactId>gradle-enterprise-maven-extension</artifactId>
             <version>1.20.1</version>
             <scope>provided</scope>
         </dependency>
+        <!-- exposes Develocity* interfaces -->
         <dependency>
             <groupId>com.gradle</groupId>
             <artifactId>develocity-maven-extension</artifactId>
-            <version>1.21-prerelease</version>
+            <version>1.21</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,13 @@
         </developer>
     </developers>
 
+    <repositories>
+        <repository>
+            <id>Develocity extension RC repository</id>
+            <url>https://repo.grdev.net/artifactory/public</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -74,7 +81,7 @@
         <dependency>
             <groupId>com.gradle</groupId>
             <artifactId>develocity-maven-extension</artifactId>
-            <version>1.21</version>
+            <version>1.21-rc-1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.gradle</groupId>
+            <artifactId>develocity-maven-extension</artifactId>
+            <version>1.21-prerelease</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>3.0.20</version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
     <version>1.13.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Gradle Enterprise Common Custom User Data Maven Extension</name>
-    <description>A Maven extension to capture common custom user data used for Maven Build Scans in Gradle Enterprise</description>
+    <name>Develocity Common Custom User Data Maven Extension</name>
+    <description>A Maven extension to capture common custom user data used for Maven Build Scans in Develocity</description>
     <url>https://github.com/gradle/common-custom-user-data-maven-extension</url>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.gradle</groupId>
     <artifactId>common-custom-user-data-maven-extension</artifactId>
-    <version>1.13.1-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Develocity Common Custom User Data Maven Extension</name>

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,2 +1,3 @@
 - [NEW] Improve tags/values in GitHub Actions `pull_request` workflows
 - [NEW] Improve tags/values in Jenkins where `GIT_BRANCH` is available
+- [NEW] Configure Develocity extension using the new API

--- a/src/main/java/com/gradle/CommonCustomUserDataDevelocityListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataDevelocityListener.java
@@ -17,7 +17,7 @@ public final class CommonCustomUserDataDevelocityListener extends CommonCustomUs
 
     @Override
     public void configure(DevelocityApi api, MavenSession session) throws MavenExecutionException {
-        super.configure(new DevelocityApiAdapter(api), session, "Develocity");
+        super.configure(new DevelocityApiAdapter(api), session, CustomConfigurationSpec.DEVELOCITY);
     }
 
 }

--- a/src/main/java/com/gradle/CommonCustomUserDataDevelocityListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataDevelocityListener.java
@@ -1,0 +1,23 @@
+package com.gradle;
+
+import com.gradle.ccud.adapters.develocity.DevelocityApiAdapter;
+import com.gradle.develocity.agent.maven.api.DevelocityApi;
+import com.gradle.develocity.agent.maven.api.DevelocityListener;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.codehaus.plexus.component.annotations.Component;
+
+@SuppressWarnings("unused")
+@Component(
+    role = DevelocityListener.class,
+    hint = "common-custom-user-data-develocity-listener",
+    description = "Captures common custom user data in Maven build scans"
+)
+public final class CommonCustomUserDataDevelocityListener extends CommonCustomUserDataListener implements DevelocityListener {
+
+    @Override
+    public void configure(DevelocityApi api, MavenSession session) throws MavenExecutionException {
+        super.configure(new DevelocityApiAdapter(api), session, "Develocity");
+    }
+
+}

--- a/src/main/java/com/gradle/CommonCustomUserDataDevelocityLogger.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataDevelocityLogger.java
@@ -1,0 +1,10 @@
+package com.gradle;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class CommonCustomUserDataDevelocityLogger {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(CommonCustomUserDataDevelocityLogger.class);
+
+}

--- a/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
@@ -1,45 +1,23 @@
 package com.gradle;
 
+import com.gradle.ccud.adapters.enterprise.GradleEnterpriseApiAdapter;
 import com.gradle.maven.extension.api.GradleEnterpriseApi;
 import com.gradle.maven.extension.api.GradleEnterpriseListener;
-import com.gradle.maven.extension.api.cache.BuildCacheApi;
-import com.gradle.maven.extension.api.scan.BuildScanApi;
+import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
 import org.codehaus.plexus.component.annotations.Component;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("unused")
 @Component(
-        role = GradleEnterpriseListener.class,
-        hint = "common-custom-user-data",
-        description = "Captures common custom user data in Maven build scans"
+    role = GradleEnterpriseListener.class,
+    hint = "common-custom-user-data-gradle-enterprise-listener",
+    description = "Captures common custom user data in Maven build scans"
 )
-public final class CommonCustomUserDataGradleEnterpriseListener implements GradleEnterpriseListener {
-
-    private final Logger logger = LoggerFactory.getLogger(CommonCustomUserDataGradleEnterpriseListener.class);
+public final class CommonCustomUserDataGradleEnterpriseListener extends CommonCustomUserDataListener implements GradleEnterpriseListener {
 
     @Override
-    public void configure(GradleEnterpriseApi api, MavenSession session) throws Exception {
-        logger.debug("Executing extension: " + getClass().getSimpleName());
-        CustomDevelocityConfig customDevelocityConfig = new CustomDevelocityConfig();
-
-        logger.debug("Configuring Gradle Enterprise");
-        customDevelocityConfig.configureGradleEnterprise(api);
-        logger.debug("Finished configuring Gradle Enterprise");
-
-        logger.debug("Configuring build scan publishing and applying build scan enhancements");
-        BuildScanApi buildScan = api.getBuildScan();
-        customDevelocityConfig.configureBuildScanPublishing(buildScan);
-        new CustomBuildScanEnhancements(buildScan, session).apply();
-        logger.debug("Finished configuring build scan publishing and applying build scan enhancements");
-
-        logger.debug("Configuring build cache");
-        BuildCacheApi buildCache = api.getBuildCache();
-        customDevelocityConfig.configureBuildCache(buildCache);
-        logger.debug("Finished configuring build cache");
-
-        GroovyScriptUserData.evaluate(session, api, logger);
+    public void configure(GradleEnterpriseApi api, MavenSession session) throws MavenExecutionException {
+        super.configure(new GradleEnterpriseApiAdapter(api), session, "Gradle Enterprise");
     }
 
 }

--- a/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
@@ -22,21 +22,21 @@ public final class CommonCustomUserDataGradleEnterpriseListener implements Gradl
     @Override
     public void configure(GradleEnterpriseApi api, MavenSession session) throws Exception {
         logger.debug("Executing extension: " + getClass().getSimpleName());
-        CustomGradleEnterpriseConfig customGradleEnterpriseConfig = new CustomGradleEnterpriseConfig();
+        CustomDevelocityConfig customDevelocityConfig = new CustomDevelocityConfig();
 
         logger.debug("Configuring Gradle Enterprise");
-        customGradleEnterpriseConfig.configureGradleEnterprise(api);
+        customDevelocityConfig.configureGradleEnterprise(api);
         logger.debug("Finished configuring Gradle Enterprise");
 
         logger.debug("Configuring build scan publishing and applying build scan enhancements");
         BuildScanApi buildScan = api.getBuildScan();
-        customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
+        customDevelocityConfig.configureBuildScanPublishing(buildScan);
         new CustomBuildScanEnhancements(buildScan, session).apply();
         logger.debug("Finished configuring build scan publishing and applying build scan enhancements");
 
         logger.debug("Configuring build cache");
         BuildCacheApi buildCache = api.getBuildCache();
-        customGradleEnterpriseConfig.configureBuildCache(buildCache);
+        customDevelocityConfig.configureBuildCache(buildCache);
         logger.debug("Finished configuring build cache");
 
         GroovyScriptUserData.evaluate(session, api, logger);

--- a/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
@@ -17,7 +17,7 @@ public final class CommonCustomUserDataGradleEnterpriseListener extends CommonCu
 
     @Override
     public void configure(GradleEnterpriseApi api, MavenSession session) throws MavenExecutionException {
-        super.configure(new GradleEnterpriseApiAdapter(api), session, "Gradle Enterprise");
+        super.configure(new GradleEnterpriseApiAdapter(api), session, CustomConfigurationSpec.DEVELOCITY);
     }
 
 }

--- a/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
@@ -17,7 +17,7 @@ public final class CommonCustomUserDataGradleEnterpriseListener extends CommonCu
 
     @Override
     public void configure(GradleEnterpriseApi api, MavenSession session) throws MavenExecutionException {
-        super.configure(new GradleEnterpriseApiAdapter(api), session, CustomConfigurationSpec.DEVELOCITY);
+        super.configure(new GradleEnterpriseApiAdapter(api), session, CustomConfigurationSpec.GRADLE_ENTERPRISE);
     }
 
 }

--- a/src/main/java/com/gradle/CommonCustomUserDataListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataListener.java
@@ -15,14 +15,14 @@ abstract class CommonCustomUserDataListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(CommonCustomUserDataListener.class);
     private static final AtomicBoolean SINGLE_APPLICATION_LOCK = new AtomicBoolean(false);
 
-    protected void configure(DevelocityAdapter api, MavenSession session, String extensionName) throws MavenExecutionException {
+    protected void configure(DevelocityAdapter api, MavenSession session, CustomConfigurationSpec customConfigurationSpec) throws MavenExecutionException {
         if (SINGLE_APPLICATION_LOCK.compareAndSet(false, true)) {
             LOGGER.debug("Executing extension: " + getClass().getSimpleName());
             CustomDevelocityConfig customDevelocityConfig = new CustomDevelocityConfig();
 
-            LOGGER.debug("Configuring {}", extensionName);
+            LOGGER.debug("Configuring {}", customConfigurationSpec.displayName);
             customDevelocityConfig.configureDevelocity(api);
-            LOGGER.debug("Finished configuring {}", extensionName);
+            LOGGER.debug("Finished configuring {}", customConfigurationSpec.displayName);
 
             LOGGER.debug("Configuring build scan publishing and applying build scan enhancements");
             BuildScanApiAdapter buildScan = api.getBuildScan();
@@ -35,7 +35,7 @@ abstract class CommonCustomUserDataListener {
             customDevelocityConfig.configureBuildCache(buildCache);
             LOGGER.debug("Finished configuring build cache");
 
-            GroovyScriptUserData.evaluate(session, api, LOGGER);
+            GroovyScriptUserData.evaluate(session, api, LOGGER, customConfigurationSpec);
         }
     }
 

--- a/src/main/java/com/gradle/CommonCustomUserDataListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataListener.java
@@ -8,35 +8,30 @@ import org.apache.maven.execution.MavenSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 abstract class CommonCustomUserDataListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CommonCustomUserDataListener.class);
-    private static final AtomicBoolean SINGLE_APPLICATION_LOCK = new AtomicBoolean(false);
 
     protected void configure(DevelocityAdapter api, MavenSession session, CustomConfigurationSpec customConfigurationSpec) throws MavenExecutionException {
-        if (SINGLE_APPLICATION_LOCK.compareAndSet(false, true)) {
-            LOGGER.debug("Executing extension: " + getClass().getSimpleName());
-            CustomDevelocityConfig customDevelocityConfig = new CustomDevelocityConfig();
+        LOGGER.debug("Executing extension: " + getClass().getSimpleName());
+        CustomDevelocityConfig customDevelocityConfig = new CustomDevelocityConfig();
 
-            LOGGER.debug("Configuring {}", customConfigurationSpec.displayName);
-            customDevelocityConfig.configureDevelocity(api);
-            LOGGER.debug("Finished configuring {}", customConfigurationSpec.displayName);
+        LOGGER.debug("Configuring {}", customConfigurationSpec.displayName);
+        customDevelocityConfig.configureDevelocity(api);
+        LOGGER.debug("Finished configuring {}", customConfigurationSpec.displayName);
 
-            LOGGER.debug("Configuring build scan publishing and applying build scan enhancements");
-            BuildScanApiAdapter buildScan = api.getBuildScan();
-            customDevelocityConfig.configureBuildScanPublishing(buildScan);
-            new CustomBuildScanEnhancements(buildScan, session).apply();
-            LOGGER.debug("Finished configuring build scan publishing and applying build scan enhancements");
+        LOGGER.debug("Configuring build scan publishing and applying build scan enhancements");
+        BuildScanApiAdapter buildScan = api.getBuildScan();
+        customDevelocityConfig.configureBuildScanPublishing(buildScan);
+        new CustomBuildScanEnhancements(buildScan, session).apply();
+        LOGGER.debug("Finished configuring build scan publishing and applying build scan enhancements");
 
-            LOGGER.debug("Configuring build cache");
-            BuildCacheApiAdapter buildCache = api.getBuildCache();
-            customDevelocityConfig.configureBuildCache(buildCache);
-            LOGGER.debug("Finished configuring build cache");
+        LOGGER.debug("Configuring build cache");
+        BuildCacheApiAdapter buildCache = api.getBuildCache();
+        customDevelocityConfig.configureBuildCache(buildCache);
+        LOGGER.debug("Finished configuring build cache");
 
-            GroovyScriptUserData.evaluate(session, api, LOGGER, customConfigurationSpec);
-        }
+        GroovyScriptUserData.evaluate(session, api, LOGGER, customConfigurationSpec);
     }
 
 }

--- a/src/main/java/com/gradle/CommonCustomUserDataListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataListener.java
@@ -1,0 +1,42 @@
+package com.gradle;
+
+import com.gradle.ccud.adapters.BuildCacheApiAdapter;
+import com.gradle.ccud.adapters.BuildScanApiAdapter;
+import com.gradle.ccud.adapters.DevelocityAdapter;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+abstract class CommonCustomUserDataListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommonCustomUserDataListener.class);
+    private static final AtomicBoolean SINGLE_APPLICATION_LOCK = new AtomicBoolean(false);
+
+    protected void configure(DevelocityAdapter api, MavenSession session, String extensionName) throws MavenExecutionException {
+        if (SINGLE_APPLICATION_LOCK.compareAndSet(false, true)) {
+            LOGGER.debug("Executing extension: " + getClass().getSimpleName());
+            CustomDevelocityConfig customDevelocityConfig = new CustomDevelocityConfig();
+
+            LOGGER.debug("Configuring {}", extensionName);
+            customDevelocityConfig.configureDevelocity(api);
+            LOGGER.debug("Finished configuring {}", extensionName);
+
+            LOGGER.debug("Configuring build scan publishing and applying build scan enhancements");
+            BuildScanApiAdapter buildScan = api.getBuildScan();
+            customDevelocityConfig.configureBuildScanPublishing(buildScan);
+            new CustomBuildScanEnhancements(buildScan, session).apply();
+            LOGGER.debug("Finished configuring build scan publishing and applying build scan enhancements");
+
+            LOGGER.debug("Configuring build cache");
+            BuildCacheApiAdapter buildCache = api.getBuildCache();
+            customDevelocityConfig.configureBuildCache(buildCache);
+            LOGGER.debug("Finished configuring build cache");
+
+            GroovyScriptUserData.evaluate(session, api, LOGGER);
+        }
+    }
+
+}

--- a/src/main/java/com/gradle/CommonCustomUserDataListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataListener.java
@@ -8,9 +8,9 @@ import org.apache.maven.execution.MavenSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-abstract class CommonCustomUserDataListener {
+import static com.gradle.CommonCustomUserDataDevelocityLogger.LOGGER;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CommonCustomUserDataListener.class);
+abstract class CommonCustomUserDataListener {
 
     protected void configure(DevelocityAdapter api, MavenSession session, CustomConfigurationSpec customConfigurationSpec) throws MavenExecutionException {
         LOGGER.debug("Executing extension: " + getClass().getSimpleName());

--- a/src/main/java/com/gradle/CommonCustomUserDataListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataListener.java
@@ -2,17 +2,15 @@ package com.gradle;
 
 import com.gradle.ccud.adapters.BuildCacheApiAdapter;
 import com.gradle.ccud.adapters.BuildScanApiAdapter;
-import com.gradle.ccud.adapters.DevelocityAdapter;
+import com.gradle.ccud.adapters.CoreApiAdapter;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static com.gradle.CommonCustomUserDataDevelocityLogger.LOGGER;
 
 abstract class CommonCustomUserDataListener {
 
-    protected void configure(DevelocityAdapter api, MavenSession session, CustomConfigurationSpec customConfigurationSpec) throws MavenExecutionException {
+    protected void configure(CoreApiAdapter api, MavenSession session, CustomConfigurationSpec customConfigurationSpec) throws MavenExecutionException {
         LOGGER.debug("Executing extension: " + getClass().getSimpleName());
         CustomDevelocityConfig customDevelocityConfig = new CustomDevelocityConfig();
 

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -1,5 +1,6 @@
 package com.gradle;
 
+import com.gradle.ccud.adapters.BuildScanApiAdapter;
 import com.gradle.maven.extension.api.scan.BuildScanApi;
 import org.apache.maven.execution.MavenSession;
 
@@ -52,10 +53,10 @@ final class CustomBuildScanEnhancements {
     private static final String SYSTEM_PROP_ECLIPSE_BUILD_ID = "eclipse.buildId";
     private static final String SYSTEM_PROP_IDEA_SYNC_ACTIVE = "idea.sync.active";
 
-    private final BuildScanApi buildScan;
+    private final BuildScanApiAdapter buildScan;
     private final MavenSession mavenSession;
 
-    CustomBuildScanEnhancements(BuildScanApi buildScan, MavenSession mavenSession) {
+    CustomBuildScanEnhancements(BuildScanApiAdapter buildScan, MavenSession mavenSession) {
         this.buildScan = buildScan;
         this.mavenSession = mavenSession;
     }
@@ -87,10 +88,10 @@ final class CustomBuildScanEnhancements {
 
     private static final class CaptureIdeMetadataAction {
 
-        private final BuildScanApi buildScan;
+        private final BuildScanApiAdapter buildScan;
         private final Map<String, Optional<String>> props;
 
-        private CaptureIdeMetadataAction(BuildScanApi buildScan, Map<String, Optional<String>> props) {
+        private CaptureIdeMetadataAction(BuildScanApiAdapter buildScan, Map<String, Optional<String>> props) {
             this.buildScan = buildScan;
             this.props = props;
         }
@@ -135,9 +136,9 @@ final class CustomBuildScanEnhancements {
     }
 
     private static final class CaptureCiMetadataAction {
-        private final BuildScanApi buildScan;
+        private final BuildScanApiAdapter buildScan;
 
-        public CaptureCiMetadataAction(BuildScanApi buildScan) {
+        public CaptureCiMetadataAction(BuildScanApiAdapter buildScan) {
             this.buildScan = buildScan;
         }
 
@@ -155,17 +156,17 @@ final class CustomBuildScanEnhancements {
 
                 buildScan.value("CI provider", ciProvider);
                 buildUrl.ifPresent(url ->
-                        buildScan.link(isJenkins() ? "Jenkins build" : "Hudson build", url));
+                    buildScan.link(isJenkins() ? "Jenkins build" : "Hudson build", url));
                 buildNumber.ifPresent(value ->
-                        buildScan.value("CI build number", value));
+                    buildScan.value("CI build number", value));
                 nodeName.ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI node", value));
+                    addCustomValueAndSearchLink(buildScan, "CI node", value, value));
                 jobName.ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI job", value));
+                    addCustomValueAndSearchLink(buildScan, "CI job", value, value));
                 stageName.ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI stage", value));
+                    addCustomValueAndSearchLink(buildScan, "CI stage", value, value));
                 controllerUrl.ifPresent(value ->
-                        buildScan.value("CI controller", value));
+                    buildScan.value("CI controller", value));
 
                 jobName.ifPresent(j -> buildNumber.ifPresent(b -> {
                     Map<String, String> params = new LinkedHashMap<>();
@@ -213,27 +214,27 @@ final class CustomBuildScanEnhancements {
             if (isCircleCI()) {
                 buildScan.value("CI provider", "CircleCI");
                 envVariable("CIRCLE_BUILD_URL").ifPresent(url ->
-                        buildScan.link("CircleCI build", url));
+                    buildScan.link("CircleCI build", url));
                 envVariable("CIRCLE_BUILD_NUM").ifPresent(value ->
-                        buildScan.value("CI build number", value));
+                    buildScan.value("CI build number", value));
                 envVariable("CIRCLE_JOB").ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI job", value));
+                    addCustomValueAndSearchLink(buildScan, "CI job", value));
                 envVariable("CIRCLE_WORKFLOW_ID").ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI workflow", value));
+                    addCustomValueAndSearchLink(buildScan, "CI workflow", value));
             }
 
             if (isBamboo()) {
                 buildScan.value("CI provider", "Bamboo");
                 envVariable("bamboo_resultsUrl").ifPresent(url ->
-                        buildScan.link("Bamboo build", url));
+                    buildScan.link("Bamboo build", url));
                 envVariable("bamboo_buildNumber").ifPresent(value ->
-                        buildScan.value("CI build number", value));
+                    buildScan.value("CI build number", value));
                 envVariable("bamboo_planName").ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI plan", value));
+                    addCustomValueAndSearchLink(buildScan, "CI plan", value));
                 envVariable("bamboo_buildPlanName").ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI build plan", value));
+                    addCustomValueAndSearchLink(buildScan, "CI build plan", value));
                 envVariable("bamboo_agentId").ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI agent", value));
+                    addCustomValueAndSearchLink(buildScan, "CI agent", value));
             }
 
             if (isGitHubActions()) {
@@ -245,7 +246,7 @@ final class CustomBuildScanEnhancements {
                     buildScan.link("GitHub Actions build", gitHubUrl.get() + "/" + gitRepository.get() + "/actions/runs/" + gitHubRunId.get());
                 }
                 envVariable("GITHUB_WORKFLOW").ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI workflow", value));
+                    addCustomValueAndSearchLink(buildScan, "CI workflow", value));
                 envVariable("GITHUB_RUN_ID").ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI run", value));
                 envVariable("GITHUB_HEAD_REF").ifPresent(value ->
@@ -255,32 +256,32 @@ final class CustomBuildScanEnhancements {
             if (isGitLab()) {
                 buildScan.value("CI provider", "GitLab");
                 envVariable("CI_JOB_URL").ifPresent(url ->
-                        buildScan.link("GitLab build", url));
+                    buildScan.link("GitLab build", url));
                 envVariable("CI_PIPELINE_URL").ifPresent(url ->
-                        buildScan.link("GitLab pipeline", url));
+                    buildScan.link("GitLab pipeline", url));
                 envVariable("CI_JOB_NAME").ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI job", value));
+                    addCustomValueAndSearchLink(buildScan, "CI job", value));
                 envVariable("CI_JOB_STAGE").ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI stage", value));
+                    addCustomValueAndSearchLink(buildScan, "CI stage", value));
             }
 
             if (isTravis()) {
                 buildScan.value("CI provider", "Travis");
                 envVariable("TRAVIS_BUILD_WEB_URL").ifPresent(url ->
-                        buildScan.link("Travis build", url));
+                    buildScan.link("Travis build", url));
                 envVariable("TRAVIS_BUILD_NUMBER").ifPresent(value ->
-                        buildScan.value("CI build number", value));
+                    buildScan.value("CI build number", value));
                 envVariable("TRAVIS_JOB_NAME").ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI job", value));
+                    addCustomValueAndSearchLink(buildScan, "CI job", value));
                 envVariable("TRAVIS_EVENT_TYPE").ifPresent(buildScan::tag);
             }
 
             if (isBitrise()) {
                 buildScan.value("CI provider", "Bitrise");
                 envVariable("BITRISE_BUILD_URL").ifPresent(url ->
-                        buildScan.link("Bitrise build", url));
+                    buildScan.link("Bitrise build", url));
                 envVariable("BITRISE_BUILD_NUMBER").ifPresent(value ->
-                        buildScan.value("CI build number", value));
+                    buildScan.value("CI build number", value));
             }
 
             if (isGoCD()) {
@@ -294,18 +295,18 @@ final class CustomBuildScanEnhancements {
                 if (Stream.of(pipelineName, pipelineNumber, stageName, stageNumber, jobName, goServerUrl).allMatch(Optional::isPresent)) {
                     //noinspection OptionalGetWithoutIsPresent
                     String buildUrl = String.format("%s/tab/build/detail/%s/%s/%s/%s/%s",
-                            goServerUrl.get(), pipelineName.get(),
-                            pipelineNumber.get(), stageName.get(), stageNumber.get(), jobName.get());
+                        goServerUrl.get(), pipelineName.get(),
+                        pipelineNumber.get(), stageName.get(), stageNumber.get(), jobName.get());
                     buildScan.link("GoCD build", buildUrl);
                 } else if (goServerUrl.isPresent()) {
                     buildScan.link("GoCD", goServerUrl.get());
                 }
                 pipelineName.ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI pipeline", value));
+                    addCustomValueAndSearchLink(buildScan, "CI pipeline", value));
                 jobName.ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI job", value));
+                    addCustomValueAndSearchLink(buildScan, "CI job", value));
                 stageName.ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI stage", value));
+                    addCustomValueAndSearchLink(buildScan, "CI stage", value));
             }
 
             if (isAzurePipelines()) {
@@ -314,26 +315,25 @@ final class CustomBuildScanEnhancements {
                 Optional<String> azureProject = envVariable("SYSTEM_TEAMPROJECT");
                 Optional<String> buildId = envVariable("BUILD_BUILDID");
                 if (Stream.of(azureServerUrl, azureProject, buildId).allMatch(Optional::isPresent)) {
-                    //noinspection OptionalGetWithoutIsPresent
                     String buildUrl = String.format("%s%s/_build/results?buildId=%s",
-                            azureServerUrl.get(), azureProject.get(), buildId.get());
+                        azureServerUrl.get(), azureProject.get(), buildId.get());
                     buildScan.link("Azure Pipelines build", buildUrl);
                 } else if (azureServerUrl.isPresent()) {
                     buildScan.link("Azure Pipelines", azureServerUrl.get());
                 }
 
                 buildId.ifPresent(value ->
-                        buildScan.value("CI build number", value));
+                    buildScan.value("CI build number", value));
             }
 
             if (isBuildkite()) {
                 buildScan.value("CI provider", "Buildkite");
                 envVariable("BUILDKITE_BUILD_URL").ifPresent(url ->
-                        buildScan.link("Buildkite build", url));
+                    buildScan.link("Buildkite build", url));
                 envVariable("BUILDKITE_COMMAND").ifPresent(command ->
-                        addCustomValueAndSearchLink(buildScan, "CI command", command));
+                    addCustomValueAndSearchLink(buildScan, "CI command", command));
                 envVariable("BUILDKITE_BUILD_ID").ifPresent(id ->
-                        buildScan.value("CI build ID", id));
+                    buildScan.value("CI build ID", id));
 
                 Optional<String> buildkitePrRepo = envVariable("BUILDKITE_PULL_REQUEST_REPO");
                 Optional<String> buildkitePrNumber = envVariable("BUILDKITE_PULL_REQUEST");
@@ -341,7 +341,7 @@ final class CustomBuildScanEnhancements {
                     // Create a GitHub link with the pr number and full repo url
                     String prNumber = buildkitePrNumber.get();
                     toWebRepoUri(buildkitePrRepo.get()).ifPresent(url ->
-                            buildScan.link("PR source", url + "/pull/" + prNumber));
+                        buildScan.link("PR source", url + "/pull/" + prNumber));
                 }
             }
         }
@@ -352,10 +352,10 @@ final class CustomBuildScanEnhancements {
         buildScan.background(new CaptureGitMetadataAction());
     }
 
-    private static final class CaptureGitMetadataAction implements Consumer<BuildScanApi> {
+    private static final class CaptureGitMetadataAction implements Consumer<BuildScanApiAdapter> {
 
         @Override
-        public void accept(BuildScanApi buildScan) {
+        public void accept(BuildScanApiAdapter buildScan) {
             if (!isGitInstalled()) {
                 return;
             }
@@ -466,18 +466,18 @@ final class CustomBuildScanEnhancements {
         });
     }
 
-    private static void addCustomValueAndSearchLink(BuildScanApi buildScan, String name, String value) {
+    private static void addCustomValueAndSearchLink(BuildScanApiAdapter buildScan, String name, String value) {
         addCustomValueAndSearchLink(buildScan, name, name, value);
     }
 
-    private static void addCustomValueAndSearchLink(BuildScanApi buildScan, String linkLabel, String name, String value) {
+    private static void addCustomValueAndSearchLink(BuildScanApiAdapter buildScan, String linkLabel, String name, String value) {
         // Set custom values immediately, but do not add custom links until 'buildFinished' since
         // creating customs links requires the server url to be fully configured
         buildScan.value(name, value);
         buildScan.buildFinished(result -> addSearchLink(buildScan, linkLabel, name, value));
     }
 
-    private static void addSearchLink(BuildScanApi buildScan, String linkLabel, Map<String, String> values) {
+    private static void addSearchLink(BuildScanApiAdapter buildScan, String linkLabel, Map<String, String> values) {
         // the parameters for a link querying multiple custom values look like:
         // search.names=name1,name2&search.values=value1,value2
         // this reduction groups all names and all values together in order to properly generate the query
@@ -487,7 +487,7 @@ final class CustomBuildScanEnhancements {
             .ifPresent(x -> buildScan.buildFinished(result -> addSearchLink(buildScan, linkLabel, x.getKey(), x.getValue())));
     }
 
-    private static void addSearchLink(BuildScanApi buildScan, String linkLabel, String name, String value) {
+    private static void addSearchLink(BuildScanApiAdapter buildScan, String linkLabel, String name, String value) {
         String server = buildScan.getServer();
         if (server != null) {
             String searchParams = "search.names=" + urlEncode(name) + "&search.values=" + urlEncode(value);

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -160,11 +160,11 @@ final class CustomBuildScanEnhancements {
                 buildNumber.ifPresent(value ->
                     buildScan.value("CI build number", value));
                 nodeName.ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI node", value, value));
+                    addCustomValueAndSearchLink(buildScan, "CI node", value));
                 jobName.ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI job", value, value));
+                    addCustomValueAndSearchLink(buildScan, "CI job", value));
                 stageName.ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI stage", value, value));
+                    addCustomValueAndSearchLink(buildScan, "CI stage", value));
                 controllerUrl.ifPresent(value ->
                     buildScan.value("CI controller", value));
 
@@ -315,6 +315,7 @@ final class CustomBuildScanEnhancements {
                 Optional<String> azureProject = envVariable("SYSTEM_TEAMPROJECT");
                 Optional<String> buildId = envVariable("BUILD_BUILDID");
                 if (Stream.of(azureServerUrl, azureProject, buildId).allMatch(Optional::isPresent)) {
+                    //noinspection OptionalGetWithoutIsPresent
                     String buildUrl = String.format("%s%s/_build/results?buildId=%s",
                         azureServerUrl.get(), azureProject.get(), buildId.get());
                     buildScan.link("Azure Pipelines build", buildUrl);

--- a/src/main/java/com/gradle/CustomConfigurationSpec.java
+++ b/src/main/java/com/gradle/CustomConfigurationSpec.java
@@ -1,0 +1,24 @@
+package com.gradle;
+
+enum CustomConfigurationSpec {
+    GRADLE_ENTERPRISE(
+        "Gradle Enterprise",
+        "gradle-enterprise-custom-user-data",
+        "gradleEnterprise"
+    ),
+    DEVELOCITY(
+        "Develocity",
+        "develocity-custom-user-data",
+        "develocity"
+    );
+
+    final String displayName;
+    final String groovyScriptName;
+    final String apiVariableName;
+
+    CustomConfigurationSpec(String displayName, String groovyScriptName, String apiVariableName) {
+        this.displayName = displayName;
+        this.groovyScriptName = groovyScriptName;
+        this.apiVariableName = apiVariableName;
+    }
+}

--- a/src/main/java/com/gradle/CustomConfigurationSpec.java
+++ b/src/main/java/com/gradle/CustomConfigurationSpec.java
@@ -1,24 +1,35 @@
 package com.gradle;
 
+import java.util.Optional;
+
 enum CustomConfigurationSpec {
     GRADLE_ENTERPRISE(
         "Gradle Enterprise",
         "gradle-enterprise-custom-user-data",
-        "gradleEnterprise"
+        "gradleEnterprise",
+        Optional.empty()
     ),
     DEVELOCITY(
         "Develocity",
         "develocity-custom-user-data",
-        "develocity"
+        "develocity",
+        Optional.of(GRADLE_ENTERPRISE)
     );
 
     final String displayName;
     final String groovyScriptName;
     final String apiVariableName;
+    final Optional<CustomConfigurationSpec> fallbackScript;
 
-    CustomConfigurationSpec(String displayName, String groovyScriptName, String apiVariableName) {
+    CustomConfigurationSpec(
+        String displayName,
+        String groovyScriptName,
+        String apiVariableName,
+        Optional<CustomConfigurationSpec> fallbackScript
+    ) {
         this.displayName = displayName;
         this.groovyScriptName = groovyScriptName;
         this.apiVariableName = apiVariableName;
+        this.fallbackScript = fallbackScript;
     }
 }

--- a/src/main/java/com/gradle/CustomDevelocityConfig.java
+++ b/src/main/java/com/gradle/CustomDevelocityConfig.java
@@ -4,16 +4,14 @@ import com.gradle.maven.extension.api.GradleEnterpriseApi;
 import com.gradle.maven.extension.api.cache.BuildCacheApi;
 import com.gradle.maven.extension.api.scan.BuildScanApi;
 
-import java.net.URI;
-
 /**
- * Provide standardized Gradle Enterprise configuration.
+ * Provide standardized Develocity configuration.
  * By applying the extension, these settings will automatically be applied.
  */
-final class CustomGradleEnterpriseConfig {
+final class CustomDevelocityConfig {
 
     void configureGradleEnterprise(GradleEnterpriseApi gradleEnterprise) {
-        /* Example of Gradle Enterprise configuration
+        /* Example of Develocity configuration
 
         gradleEnterprise.setServer("https://enterprise-samples.gradle.com");
         gradleEnterprise.setAllowUntrustedServer(false);

--- a/src/main/java/com/gradle/CustomDevelocityConfig.java
+++ b/src/main/java/com/gradle/CustomDevelocityConfig.java
@@ -1,8 +1,8 @@
 package com.gradle;
 
-import com.gradle.maven.extension.api.GradleEnterpriseApi;
-import com.gradle.maven.extension.api.cache.BuildCacheApi;
-import com.gradle.maven.extension.api.scan.BuildScanApi;
+import com.gradle.ccud.adapters.BuildCacheApiAdapter;
+import com.gradle.ccud.adapters.BuildScanApiAdapter;
+import com.gradle.ccud.adapters.DevelocityAdapter;
 
 /**
  * Provide standardized Develocity configuration.
@@ -10,16 +10,16 @@ import com.gradle.maven.extension.api.scan.BuildScanApi;
  */
 final class CustomDevelocityConfig {
 
-    void configureGradleEnterprise(GradleEnterpriseApi gradleEnterprise) {
+    void configureDevelocity(DevelocityAdapter develocity) {
         /* Example of Develocity configuration
 
-        gradleEnterprise.setServer("https://enterprise-samples.gradle.com");
-        gradleEnterprise.setAllowUntrustedServer(false);
+        develocity.setServer("https://enterprise-samples.gradle.com");
+        develocity.setAllowUntrustedServer(false);
 
         */
     }
 
-    void configureBuildScanPublishing(BuildScanApi buildScans) {
+    void configureBuildScanPublishing(BuildScanApiAdapter buildScans) {
         /* Example of build scan publishing configuration
 
         boolean isCiServer = System.getenv().containsKey("CI");
@@ -31,7 +31,7 @@ final class CustomDevelocityConfig {
         */
     }
 
-    void configureBuildCache(BuildCacheApi buildCache) {
+    void configureBuildCache(BuildCacheApiAdapter buildCache) {
         /* Example of build cache configuration
 
         boolean isCiServer = System.getenv().containsKey("CI");

--- a/src/main/java/com/gradle/CustomDevelocityConfig.java
+++ b/src/main/java/com/gradle/CustomDevelocityConfig.java
@@ -2,7 +2,7 @@ package com.gradle;
 
 import com.gradle.ccud.adapters.BuildCacheApiAdapter;
 import com.gradle.ccud.adapters.BuildScanApiAdapter;
-import com.gradle.ccud.adapters.DevelocityAdapter;
+import com.gradle.ccud.adapters.CoreApiAdapter;
 
 /**
  * Provide standardized Develocity configuration.
@@ -10,7 +10,7 @@ import com.gradle.ccud.adapters.DevelocityAdapter;
  */
 final class CustomDevelocityConfig {
 
-    void configureDevelocity(DevelocityAdapter develocity) {
+    void configureDevelocity(CoreApiAdapter develocity) {
         /* Example of Develocity configuration
 
         develocity.setServer("https://enterprise-samples.gradle.com");

--- a/src/main/java/com/gradle/GroovyScriptUserData.java
+++ b/src/main/java/com/gradle/GroovyScriptUserData.java
@@ -1,6 +1,6 @@
 package com.gradle;
 
-import com.gradle.ccud.adapters.DevelocityAdapter;
+import com.gradle.ccud.adapters.CoreApiAdapter;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import org.apache.maven.MavenExecutionException;
@@ -11,7 +11,7 @@ import java.io.File;
 
 final class GroovyScriptUserData {
 
-    static void evaluate(MavenSession session, DevelocityAdapter develocity, Logger logger, CustomConfigurationSpec customConfigurationSpec) throws MavenExecutionException {
+    static void evaluate(MavenSession session, CoreApiAdapter develocity, Logger logger, CustomConfigurationSpec customConfigurationSpec) throws MavenExecutionException {
         File script = getGroovyScript(session, customConfigurationSpec.groovyScriptName);
         if (script.exists()) {
             logger.debug("Evaluating custom user data Groovy script: {}", script);
@@ -35,7 +35,7 @@ final class GroovyScriptUserData {
         return new File(rootDir, ".mvn/" + scriptName + ".groovy");
     }
 
-    private static void evaluateGroovyScript(MavenSession session, DevelocityAdapter develocity, Logger logger, File groovyScript, String apiVariableName) throws MavenExecutionException {
+    private static void evaluateGroovyScript(MavenSession session, CoreApiAdapter develocity, Logger logger, File groovyScript, String apiVariableName) throws MavenExecutionException {
         try {
             Binding binding = prepareBinding(session, develocity, logger, apiVariableName);
             new GroovyShell(GroovyScriptUserData.class.getClassLoader(), binding).evaluate(groovyScript);
@@ -44,7 +44,7 @@ final class GroovyScriptUserData {
         }
     }
 
-    private static Binding prepareBinding(MavenSession session, DevelocityAdapter develocity, Logger logger, String apiVariableName) {
+    private static Binding prepareBinding(MavenSession session, CoreApiAdapter develocity, Logger logger, String apiVariableName) {
         Binding binding = new Binding();
         binding.setVariable("project", session.getTopLevelProject());
         binding.setVariable("session", session);

--- a/src/main/java/com/gradle/GroovyScriptUserData.java
+++ b/src/main/java/com/gradle/GroovyScriptUserData.java
@@ -14,10 +14,19 @@ final class GroovyScriptUserData {
     static void evaluate(MavenSession session, DevelocityAdapter develocity, Logger logger, CustomConfigurationSpec customConfigurationSpec) throws MavenExecutionException {
         File script = getGroovyScript(session, customConfigurationSpec.groovyScriptName);
         if (script.exists()) {
-            logger.debug("Evaluating custom user data Groovy script: " + script);
+            logger.debug("Evaluating custom user data Groovy script: {}", script);
             evaluateGroovyScript(session, develocity, logger, script, customConfigurationSpec.apiVariableName);
-        } else {
+        } else if (!customConfigurationSpec.fallbackScript.isPresent()) {
             logger.debug("Skipping evaluation of custom user data Groovy script because it does not exist: " + script);
+        } else {
+            CustomConfigurationSpec fallbackSpec = customConfigurationSpec.fallbackScript.get();
+            File fallbackScript = getGroovyScript(session, fallbackSpec.groovyScriptName);
+            if (fallbackScript.exists()) {
+                logger.warn("Evaluating deprecated custom user data Groovy script: {}. Use '{}.groovy' scripts instead.", fallbackScript, customConfigurationSpec.groovyScriptName);
+                evaluateGroovyScript(session, develocity, logger, fallbackScript, fallbackSpec.apiVariableName);
+            } else {
+                logger.debug("Skipping evaluation of custom user data Groovy script because it does not exist: " + fallbackScript);
+            }
         }
     }
 

--- a/src/main/java/com/gradle/GroovyScriptUserData.java
+++ b/src/main/java/com/gradle/GroovyScriptUserData.java
@@ -1,6 +1,6 @@
 package com.gradle;
 
-import com.gradle.maven.extension.api.GradleEnterpriseApi;
+import com.gradle.ccud.adapters.DevelocityAdapter;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import org.apache.maven.MavenExecutionException;
@@ -8,40 +8,48 @@ import org.apache.maven.execution.MavenSession;
 import org.slf4j.Logger;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
 final class GroovyScriptUserData {
 
-    static void evaluate(MavenSession session, GradleEnterpriseApi gradleEnterprise, Logger logger) throws MavenExecutionException {
-        File groovyScript = getGroovyScript(session);
-        if (groovyScript.exists()) {
-            logger.debug("Evaluating custom user data Groovy script: " + groovyScript);
-            evaluateGroovyScript(session, gradleEnterprise, logger, groovyScript);
-        } else {
-            logger.debug("Skipping evaluation of custom user data Groovy script because it does not exist: " + groovyScript);
+    static void evaluate(MavenSession session, DevelocityAdapter develocity, Logger logger) throws MavenExecutionException {
+        List<File> groovyScripts = getGroovyScripts(session);
+        for (File script : groovyScripts) {
+            if (script.exists()) {
+                logger.debug("Evaluating custom user data Groovy script: " + script);
+                evaluateGroovyScript(session, develocity, logger, script);
+            } else {
+                logger.debug("Skipping evaluation of custom user data Groovy script because it does not exist: " + script);
+            }
         }
     }
 
-    private static File getGroovyScript(MavenSession session) {
+    private static List<File> getGroovyScripts(MavenSession session) {
         File rootDir = session.getRequest().getMultiModuleProjectDirectory();
-        return new File(rootDir, ".mvn/gradle-enterprise-custom-user-data.groovy");
+        return Arrays.asList(
+            new File(rootDir, ".mvn/gradle-enterprise-custom-user-data.groovy"),
+            new File(rootDir, ".mvn/develocity-custom-user-data.groovy")
+        );
     }
 
-    private static void evaluateGroovyScript(MavenSession session, GradleEnterpriseApi gradleEnterprise, Logger logger, File groovyScript) throws MavenExecutionException {
+    private static void evaluateGroovyScript(MavenSession session, DevelocityAdapter develocity, Logger logger, File groovyScript) throws MavenExecutionException {
         try {
-            Binding binding = prepareBinding(session, gradleEnterprise, logger);
+            Binding binding = prepareBinding(session, develocity, logger);
             new GroovyShell(GroovyScriptUserData.class.getClassLoader(), binding).evaluate(groovyScript);
         } catch (Exception e) {
             throw new MavenExecutionException("Failed to evaluate custom user data Groovy script: " + groovyScript, e);
         }
     }
 
-    private static Binding prepareBinding(MavenSession session, GradleEnterpriseApi gradleEnterprise, Logger logger) {
+    private static Binding prepareBinding(MavenSession session, DevelocityAdapter develocity, Logger logger) {
         Binding binding = new Binding();
         binding.setVariable("project", session.getTopLevelProject());
         binding.setVariable("session", session);
-        binding.setVariable("gradleEnterprise", gradleEnterprise);
-        binding.setVariable("buildScan", gradleEnterprise.getBuildScan());
-        binding.setVariable("buildCache", gradleEnterprise.getBuildCache());
+        binding.setVariable("develocity", develocity);
+        binding.setVariable("gradleEnterprise", develocity);
+        binding.setVariable("buildScan", develocity.getBuildScan());
+        binding.setVariable("buildCache", develocity.getBuildCache());
         binding.setVariable("log", logger);
         return binding;
     }

--- a/src/main/java/com/gradle/ccud/adapters/BuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildCacheApiAdapter.java
@@ -1,5 +1,9 @@
 package com.gradle.ccud.adapters;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.cache.BuildCacheApi
+ * @see com.gradle.maven.extension.api.cache.BuildCacheApi
+ */
 public interface BuildCacheApiAdapter {
 
     LocalBuildCacheAdapter getLocal();

--- a/src/main/java/com/gradle/ccud/adapters/BuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildCacheApiAdapter.java
@@ -1,0 +1,17 @@
+package com.gradle.ccud.adapters;
+
+public interface BuildCacheApiAdapter {
+
+    LocalBuildCacheAdapter getLocal();
+
+    RemoteBuildCacheAdapter getRemote();
+
+    boolean isRequireClean();
+
+    void setRequireClean(boolean requireClean);
+
+    void registerMojoMetadataProvider(MojoMetadataProviderAdapter metadataProvider);
+
+    void registerNormalizationProvider(NormalizationProviderAdapter normalizationProvider);
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/BuildResultAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildResultAdapter.java
@@ -4,28 +4,6 @@ import java.util.List;
 
 public interface BuildResultAdapter {
 
-    static BuildResultAdapter from(com.gradle.maven.extension.api.scan.BuildResult result) {
-        return new DefaultBuildResultAdapter(result.getFailures());
-    }
-
-    static BuildResultAdapter from(com.gradle.develocity.agent.maven.api.scan.BuildResult result) {
-        return new DefaultBuildResultAdapter(result.getFailures());
-    }
-
     List<Throwable> getFailures();
-
-    class DefaultBuildResultAdapter implements BuildResultAdapter {
-
-        private final List<Throwable> failures;
-
-        private DefaultBuildResultAdapter(List<Throwable> failures) {
-            this.failures = failures;
-        }
-
-        @Override
-        public List<Throwable> getFailures() {
-            return failures;
-        }
-    }
 
 }

--- a/src/main/java/com/gradle/ccud/adapters/BuildResultAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildResultAdapter.java
@@ -1,0 +1,9 @@
+package com.gradle.ccud.adapters;
+
+import java.util.List;
+
+public interface BuildResultAdapter {
+
+    List<Throwable> getFailures();
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/BuildResultAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildResultAdapter.java
@@ -4,6 +4,28 @@ import java.util.List;
 
 public interface BuildResultAdapter {
 
+    static BuildResultAdapter from(com.gradle.maven.extension.api.scan.BuildResult result) {
+        return new DefaultBuildResultAdapter(result.getFailures());
+    }
+
+    static BuildResultAdapter from(com.gradle.develocity.agent.maven.api.scan.BuildResult result) {
+        return new DefaultBuildResultAdapter(result.getFailures());
+    }
+
     List<Throwable> getFailures();
+
+    class DefaultBuildResultAdapter implements BuildResultAdapter {
+
+        private final List<Throwable> failures;
+
+        private DefaultBuildResultAdapter(List<Throwable> failures) {
+            this.failures = failures;
+        }
+
+        @Override
+        public List<Throwable> getFailures() {
+            return failures;
+        }
+    }
 
 }

--- a/src/main/java/com/gradle/ccud/adapters/BuildResultAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildResultAdapter.java
@@ -2,6 +2,10 @@ package com.gradle.ccud.adapters;
 
 import java.util.List;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.scan.BuildResult
+ * @see com.gradle.maven.extension.api.scan.BuildResult
+ */
 public interface BuildResultAdapter {
 
     List<Throwable> getFailures();

--- a/src/main/java/com/gradle/ccud/adapters/BuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildScanApiAdapter.java
@@ -3,6 +3,10 @@ package com.gradle.ccud.adapters;
 import java.net.URI;
 import java.util.function.Consumer;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.scan.BuildScanApi
+ * @see com.gradle.maven.extension.api.scan.BuildScanApi
+ */
 public interface BuildScanApiAdapter {
 
     void tag(String tag);

--- a/src/main/java/com/gradle/ccud/adapters/BuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildScanApiAdapter.java
@@ -1,0 +1,64 @@
+package com.gradle.ccud.adapters;
+
+import java.net.URI;
+import java.util.function.Consumer;
+
+public interface BuildScanApiAdapter {
+
+    void tag(String tag);
+
+    void value(String name, String value);
+
+    void link(String name, String url);
+
+    void background(Consumer<? super BuildScanApiAdapter> action);
+
+    void buildFinished(Consumer<? super BuildResultAdapter> action);
+
+    void buildScanPublished(Consumer<? super PublishedBuildScanAdapter> action);
+
+    void setTermsOfServiceUrl(String termsOfServiceUrl);
+
+    String getTermsOfServiceUrl();
+
+    void setTermsOfServiceAgree(String agree);
+
+    String getTermsOfServiceAgree();
+
+    default void setServer(String url) {
+        setServer(url == null ? null : URI.create(url));
+    }
+
+    void setServer(URI url);
+
+    String getServer();
+
+    void setAllowUntrustedServer(boolean allow);
+
+    boolean getAllowUntrustedServer();
+
+    void publishAlways();
+
+    void publishAlwaysIf(boolean condition);
+
+    void publishOnFailure();
+
+    void publishOnFailureIf(boolean condition);
+
+    void publishOnDemand();
+
+    void setUploadInBackground(boolean uploadInBackground);
+
+    boolean isUploadInBackground();
+
+    void executeOnce(String identifier, Consumer<? super BuildScanApiAdapter> action);
+
+    BuildScanDataObfuscationAdapter getObfuscation();
+
+    void obfuscation(Consumer<? super BuildScanDataObfuscationAdapter> action);
+
+    BuildScanCaptureAdapter getCapture();
+
+    void capture(Consumer<? super BuildScanCaptureAdapter> action);
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/BuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildScanApiAdapter.java
@@ -61,6 +61,8 @@ public interface BuildScanApiAdapter {
 
     BuildScanCaptureAdapter getCapture();
 
-    void capture(Consumer<? super BuildScanCaptureAdapter> action);
+    default void capture(Consumer<? super BuildScanCaptureAdapter> action) {
+        action.accept(getCapture());
+    }
 
 }

--- a/src/main/java/com/gradle/ccud/adapters/BuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildScanApiAdapter.java
@@ -55,7 +55,9 @@ public interface BuildScanApiAdapter {
 
     BuildScanDataObfuscationAdapter getObfuscation();
 
-    void obfuscation(Consumer<? super BuildScanDataObfuscationAdapter> action);
+    default void obfuscation(Consumer<? super BuildScanDataObfuscationAdapter> action) {
+        action.accept(getObfuscation());
+    }
 
     BuildScanCaptureAdapter getCapture();
 

--- a/src/main/java/com/gradle/ccud/adapters/BuildScanCaptureAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildScanCaptureAdapter.java
@@ -1,5 +1,9 @@
 package com.gradle.ccud.adapters;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.scan.BuildScanCaptureSettings
+ * @see com.gradle.maven.extension.api.scan.BuildScanCaptureSettings
+ */
 public interface BuildScanCaptureAdapter {
 
     void setGoalInputFiles(boolean capture);

--- a/src/main/java/com/gradle/ccud/adapters/BuildScanCaptureAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildScanCaptureAdapter.java
@@ -1,0 +1,17 @@
+package com.gradle.ccud.adapters;
+
+public interface BuildScanCaptureAdapter {
+
+    void setGoalInputFiles(boolean capture);
+
+    boolean isGoalInputFiles();
+
+    void setBuildLogging(boolean capture);
+
+    boolean isBuildLogging();
+
+    void setTestLogging(boolean capture);
+
+    boolean isTestLogging();
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/BuildScanDataObfuscationAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildScanDataObfuscationAdapter.java
@@ -1,0 +1,15 @@
+package com.gradle.ccud.adapters;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.function.Function;
+
+public interface BuildScanDataObfuscationAdapter {
+
+    void username(Function<? super String, ? extends String> obfuscator);
+
+    void hostname(Function<? super String, ? extends String> obfuscator);
+
+    void ipAddresses(Function<? super List<InetAddress>, ? extends List<String>> obfuscator);
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/BuildScanDataObfuscationAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildScanDataObfuscationAdapter.java
@@ -2,6 +2,7 @@ package com.gradle.ccud.adapters;
 
 import java.net.InetAddress;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 public interface BuildScanDataObfuscationAdapter {
@@ -11,5 +12,9 @@ public interface BuildScanDataObfuscationAdapter {
     void hostname(Function<? super String, ? extends String> obfuscator);
 
     void ipAddresses(Function<? super List<InetAddress>, ? extends List<String>> obfuscator);
+
+    @FunctionalInterface
+    interface ObfuscatorConsumer<I, O> extends Consumer<Function<? super I, ? extends O>> {
+    }
 
 }

--- a/src/main/java/com/gradle/ccud/adapters/BuildScanDataObfuscationAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildScanDataObfuscationAdapter.java
@@ -5,6 +5,10 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.scan.BuildScanDataObfuscation
+ * @see com.gradle.maven.extension.api.scan.BuildScanDataObfuscation
+ */
 public interface BuildScanDataObfuscationAdapter {
 
     void username(Function<? super String, ? extends String> obfuscator);

--- a/src/main/java/com/gradle/ccud/adapters/CleanupPolicyAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/CleanupPolicyAdapter.java
@@ -2,6 +2,10 @@ package com.gradle.ccud.adapters;
 
 import java.time.Duration;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.cache.CleanupPolicy
+ * @see com.gradle.maven.extension.api.cache.CleanupPolicy
+ */
 public interface CleanupPolicyAdapter {
 
     boolean isEnabled();

--- a/src/main/java/com/gradle/ccud/adapters/CleanupPolicyAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/CleanupPolicyAdapter.java
@@ -1,0 +1,19 @@
+package com.gradle.ccud.adapters;
+
+import java.time.Duration;
+
+public interface CleanupPolicyAdapter {
+
+    boolean isEnabled();
+
+    void setEnabled(boolean enabled);
+
+    Duration getRetentionPeriod();
+
+    void setRetentionPeriod(Duration retentionPeriod);
+
+    Duration getCleanupInterval();
+
+    void setCleanupInterval(Duration cleanupInterval);
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/CoreApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/CoreApiAdapter.java
@@ -7,7 +7,7 @@ import java.nio.file.Path;
  * @see com.gradle.develocity.agent.maven.api.DevelocityApi
  * @see com.gradle.maven.extension.api.GradleEnterpriseApi
  */
-public interface DevelocityAdapter {
+public interface CoreApiAdapter {
 
     boolean isEnabled();
 

--- a/src/main/java/com/gradle/ccud/adapters/CredentialsAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/CredentialsAdapter.java
@@ -1,0 +1,13 @@
+package com.gradle.ccud.adapters;
+
+public interface CredentialsAdapter {
+
+    String getUsername();
+
+    void setUsername(String username);
+
+    String getPassword();
+
+    void setPassword(String password);
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/CredentialsAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/CredentialsAdapter.java
@@ -1,5 +1,9 @@
 package com.gradle.ccud.adapters;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.cache.Credentials
+ * @see com.gradle.maven.extension.api.cache.Credentials
+ */
 public interface CredentialsAdapter {
 
     String getUsername();

--- a/src/main/java/com/gradle/ccud/adapters/DevelocityAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/DevelocityAdapter.java
@@ -1,0 +1,40 @@
+package com.gradle.ccud.adapters;
+
+import java.net.URI;
+import java.nio.file.Path;
+
+public interface DevelocityAdapter {
+
+    boolean isEnabled();
+
+    void setEnabled(boolean enabled);
+
+    void setProjectId(String projectId);
+
+    String getProjectId();
+
+    Path getStorageDirectory();
+
+    void setStorageDirectory(Path path);
+
+    default void setServer(String url) {
+        setServer(url == null ? null : URI.create(url));
+    }
+
+    void setServer(URI url);
+
+    String getServer();
+
+    void setAllowUntrustedServer(boolean allow);
+
+    boolean getAllowUntrustedServer();
+
+    void setAccessKey(String accessKey);
+
+    String getAccessKey();
+
+    BuildScanApiAdapter getBuildScan();
+
+    BuildCacheApiAdapter getBuildCache();
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/DevelocityAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/DevelocityAdapter.java
@@ -3,6 +3,10 @@ package com.gradle.ccud.adapters;
 import java.net.URI;
 import java.nio.file.Path;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.DevelocityApi
+ * @see com.gradle.maven.extension.api.GradleEnterpriseApi
+ */
 public interface DevelocityAdapter {
 
     boolean isEnabled();

--- a/src/main/java/com/gradle/ccud/adapters/DevelocityAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/DevelocityAdapter.java
@@ -37,4 +37,6 @@ public interface DevelocityAdapter {
 
     BuildCacheApiAdapter getBuildCache();
 
+    boolean isDevelocityApi();
+
 }

--- a/src/main/java/com/gradle/ccud/adapters/LocalBuildCacheAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/LocalBuildCacheAdapter.java
@@ -1,0 +1,21 @@
+package com.gradle.ccud.adapters;
+
+import java.io.File;
+
+public interface LocalBuildCacheAdapter {
+
+    boolean isEnabled();
+
+    void setEnabled(boolean enabled);
+
+    boolean isStoreEnabled();
+
+    void setStoreEnabled(boolean storeEnabled);
+
+    File getDirectory();
+
+    void setDirectory(File directory);
+
+    CleanupPolicyAdapter getCleanupPolicy();
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/LocalBuildCacheAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/LocalBuildCacheAdapter.java
@@ -2,6 +2,10 @@ package com.gradle.ccud.adapters;
 
 import java.io.File;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.cache.LocalBuildCache
+ * @see com.gradle.maven.extension.api.cache.LocalBuildCache
+ */
 public interface LocalBuildCacheAdapter {
 
     boolean isEnabled();

--- a/src/main/java/com/gradle/ccud/adapters/MojoMetadataProviderAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/MojoMetadataProviderAdapter.java
@@ -1,0 +1,113 @@
+package com.gradle.ccud.adapters;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public interface MojoMetadataProviderAdapter {
+
+    void provideMetadata(Context context);
+
+    interface Context {
+        Object getUnderlyingObject();
+
+        MojoExecution getMojoExecution();
+
+        MavenProject getProject();
+
+        MavenSession getSession();
+
+        void withPlugin(String artifactId, Runnable action);
+
+        Context skipIfTrue(String... propertyNames);
+
+        Context skipIfTrue(List<String> propertyNames);
+
+        Context inputs(Consumer<? super Context.Inputs> action);
+
+        Context outputs(Consumer<? super Context.Outputs> action);
+
+        Context localState(Consumer<? super Context.LocalState> action);
+
+        Context nested(String propertyName, Consumer<? super Context> action);
+
+        Context iterate(String propertyName, Consumer<? super Context> action);
+
+        interface LocalState {
+            LocalState files(String propertyName);
+
+            LocalState files(String propertyName, Object value);
+        }
+
+        interface Outputs {
+            Outputs file(String propertyName);
+
+            Outputs file(String propertyName, Object file);
+
+            Outputs directory(String propertyName);
+
+            Outputs directory(String propertyName, Object directory);
+
+            Outputs cacheable(String reason);
+
+            Outputs notCacheableBecause(String reason);
+
+            Outputs storeEnabled(boolean enabled);
+        }
+
+        interface FileSet {
+            FileSet includesProperty(String includePropertyName);
+
+            FileSet include(List<String> includePatterns);
+
+            FileSet include(String... includePatterns);
+
+            FileSet excludesProperty(String excludePropertyName);
+
+            FileSet exclude(List<String> excludePatterns);
+
+            FileSet exclude(String... excludePatterns);
+
+            FileSet normalizationStrategy(NormalizationStrategy normalizationStrategy);
+
+            FileSet emptyDirectoryHandling(EmptyDirectoryHandling emptyDirectoryHandling);
+
+            FileSet lineEndingHandling(LineEndingHandling lineEndingHandling);
+
+            enum LineEndingHandling {
+                DEFAULT,
+                NORMALIZE
+            }
+
+            enum EmptyDirectoryHandling {
+                DEFAULT,
+                IGNORE
+            }
+
+            enum NormalizationStrategy {
+                ABSOLUTE_PATH,
+                CLASSPATH,
+                COMPILE_CLASSPATH,
+                IGNORED_PATH,
+                NAME_ONLY,
+                RELATIVE_PATH
+            }
+        }
+
+        interface Inputs {
+            Inputs properties(String... propertyNames);
+
+            Inputs property(String propertyName, Object value);
+
+            Inputs fileSet(String propertyName, Consumer<FileSet> action);
+
+            Inputs fileSet(String propertyName, Object files, Consumer<FileSet> action);
+
+            Inputs ignore(String... propertyNames);
+        }
+    }
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/MojoMetadataProviderAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/MojoMetadataProviderAdapter.java
@@ -4,6 +4,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -22,7 +23,10 @@ public interface MojoMetadataProviderAdapter {
 
         void withPlugin(String artifactId, Runnable action);
 
-        Context skipIfTrue(String... propertyNames);
+        default Context skipIfTrue(String... propertyNames) {
+            skipIfTrue(Arrays.asList(propertyNames));
+            return this;
+        }
 
         Context skipIfTrue(List<String> propertyNames);
 
@@ -63,13 +67,19 @@ public interface MojoMetadataProviderAdapter {
 
             FileSet include(List<String> includePatterns);
 
-            FileSet include(String... includePatterns);
+            default FileSet include(String... includePatterns) {
+                include(Arrays.asList(includePatterns));
+                return this;
+            }
 
             FileSet excludesProperty(String excludePropertyName);
 
             FileSet exclude(List<String> excludePatterns);
 
-            FileSet exclude(String... excludePatterns);
+            default FileSet exclude(String... excludePatterns) {
+                exclude(Arrays.asList(excludePatterns));
+                return this;
+            }
 
             FileSet normalizationStrategy(NormalizationStrategy normalizationStrategy);
 

--- a/src/main/java/com/gradle/ccud/adapters/MojoMetadataProviderAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/MojoMetadataProviderAdapter.java
@@ -8,6 +8,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.cache.MojoMetadataProvider
+ * @see com.gradle.maven.extension.api.cache.MojoMetadataProvider
+ */
 public interface MojoMetadataProviderAdapter {
 
     void provideMetadata(Context context);
@@ -24,8 +28,7 @@ public interface MojoMetadataProviderAdapter {
         void withPlugin(String artifactId, Runnable action);
 
         default Context skipIfTrue(String... propertyNames) {
-            skipIfTrue(Arrays.asList(propertyNames));
-            return this;
+            return skipIfTrue(Arrays.asList(propertyNames));
         }
 
         Context skipIfTrue(List<String> propertyNames);
@@ -68,8 +71,7 @@ public interface MojoMetadataProviderAdapter {
             FileSet include(List<String> includePatterns);
 
             default FileSet include(String... includePatterns) {
-                include(Arrays.asList(includePatterns));
-                return this;
+                return include(Arrays.asList(includePatterns));
             }
 
             FileSet excludesProperty(String excludePropertyName);
@@ -77,8 +79,7 @@ public interface MojoMetadataProviderAdapter {
             FileSet exclude(List<String> excludePatterns);
 
             default FileSet exclude(String... excludePatterns) {
-                exclude(Arrays.asList(excludePatterns));
-                return this;
+                return exclude(Arrays.asList(excludePatterns));
             }
 
             FileSet normalizationStrategy(NormalizationStrategy normalizationStrategy);

--- a/src/main/java/com/gradle/ccud/adapters/NormalizationProviderAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/NormalizationProviderAdapter.java
@@ -3,6 +3,7 @@ package com.gradle.ccud.adapters;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -11,11 +12,17 @@ public interface NormalizationProviderAdapter {
     void configureNormalization(Context context);
 
     interface SystemPropertiesNormalization {
-        SystemPropertiesNormalization setIgnoredKeys(String... systemPropertyNames);
+        default SystemPropertiesNormalization setIgnoredKeys(String... systemPropertyNames) {
+            setIgnoredKeys(Arrays.asList(systemPropertyNames));
+            return this;
+        }
 
         SystemPropertiesNormalization setIgnoredKeys(List<String> systemPropertyNames);
 
-        SystemPropertiesNormalization addIgnoredKeys(String... systemPropertyNames);
+        default SystemPropertiesNormalization addIgnoredKeys(String... systemPropertyNames) {
+            addIgnoredKeys(Arrays.asList(systemPropertyNames));
+            return this;
+        }
 
         SystemPropertiesNormalization addIgnoredKeys(List<String> systemPropertyNames);
     }
@@ -23,34 +30,55 @@ public interface NormalizationProviderAdapter {
     interface RuntimeClasspathNormalization {
         RuntimeClasspathNormalization setIgnoredFiles(List<String> ignoredFiles);
 
-        RuntimeClasspathNormalization setIgnoredFiles(String... ignoredFiles);
+        default RuntimeClasspathNormalization setIgnoredFiles(String... ignoredFiles) {
+            setIgnoredFiles(Arrays.asList(ignoredFiles));
+            return this;
+        }
 
         RuntimeClasspathNormalization addIgnoredFiles(List<String> ignoredFiles);
 
-        RuntimeClasspathNormalization addIgnoredFiles(String... ignoredFiles);
+        default RuntimeClasspathNormalization addIgnoredFiles(String... ignoredFiles) {
+            addIgnoredFiles(Arrays.asList(ignoredFiles));
+            return this;
+        }
 
         RuntimeClasspathNormalization addPropertiesNormalization(String path, List<String> ignoredProperties);
 
-        RuntimeClasspathNormalization addPropertiesNormalization(String path, String... ignoredProperties);
+        default RuntimeClasspathNormalization addPropertiesNormalization(String path, String... ignoredProperties) {
+            addPropertiesNormalization(path, Arrays.asList(ignoredProperties));
+            return this;
+        }
 
         RuntimeClasspathNormalization configureMetaInf(Consumer<RuntimeClasspathNormalization.MetaInf> action);
 
         interface MetaInf {
             RuntimeClasspathNormalization.MetaInf setIgnoredAttributes(List<String> ignoredAttributes);
 
-            RuntimeClasspathNormalization.MetaInf setIgnoredAttributes(String... ignoredAttributes);
+            default RuntimeClasspathNormalization.MetaInf setIgnoredAttributes(String... ignoredAttributes) {
+                setIgnoredAttributes(Arrays.asList(ignoredAttributes));
+                return this;
+            }
 
             RuntimeClasspathNormalization.MetaInf addIgnoredAttributes(List<String> ignoredAttributes);
 
-            RuntimeClasspathNormalization.MetaInf addIgnoredAttributes(String... ignoredAttributes);
+            default RuntimeClasspathNormalization.MetaInf addIgnoredAttributes(String... ignoredAttributes) {
+                addIgnoredAttributes(Arrays.asList(ignoredAttributes));
+                return this;
+            }
 
             RuntimeClasspathNormalization.MetaInf setIgnoredProperties(List<String> ignoredProperties);
 
-            RuntimeClasspathNormalization.MetaInf setIgnoredProperties(String... ignoredProperties);
+            default RuntimeClasspathNormalization.MetaInf setIgnoredProperties(String... ignoredProperties) {
+                setIgnoredProperties(Arrays.asList(ignoredProperties));
+                return this;
+            }
 
             RuntimeClasspathNormalization.MetaInf addIgnoredProperties(List<String> ignoredProperties);
 
-            RuntimeClasspathNormalization.MetaInf addIgnoredProperties(String... ignoredProperties);
+            default RuntimeClasspathNormalization.MetaInf addIgnoredProperties(String... ignoredProperties) {
+                addIgnoredProperties(Arrays.asList(ignoredProperties));
+                return this;
+            }
 
             RuntimeClasspathNormalization.MetaInf setIgnoreManifest(boolean ignoreManifest);
 

--- a/src/main/java/com/gradle/ccud/adapters/NormalizationProviderAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/NormalizationProviderAdapter.java
@@ -1,0 +1,70 @@
+package com.gradle.ccud.adapters;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public interface NormalizationProviderAdapter {
+
+    void configureNormalization(Context context);
+
+    interface SystemPropertiesNormalization {
+        SystemPropertiesNormalization setIgnoredKeys(String... systemPropertyNames);
+
+        SystemPropertiesNormalization setIgnoredKeys(List<String> systemPropertyNames);
+
+        SystemPropertiesNormalization addIgnoredKeys(String... systemPropertyNames);
+
+        SystemPropertiesNormalization addIgnoredKeys(List<String> systemPropertyNames);
+    }
+
+    interface RuntimeClasspathNormalization {
+        RuntimeClasspathNormalization setIgnoredFiles(List<String> ignoredFiles);
+
+        RuntimeClasspathNormalization setIgnoredFiles(String... ignoredFiles);
+
+        RuntimeClasspathNormalization addIgnoredFiles(List<String> ignoredFiles);
+
+        RuntimeClasspathNormalization addIgnoredFiles(String... ignoredFiles);
+
+        RuntimeClasspathNormalization addPropertiesNormalization(String path, List<String> ignoredProperties);
+
+        RuntimeClasspathNormalization addPropertiesNormalization(String path, String... ignoredProperties);
+
+        RuntimeClasspathNormalization configureMetaInf(Consumer<RuntimeClasspathNormalization.MetaInf> action);
+
+        interface MetaInf {
+            RuntimeClasspathNormalization.MetaInf setIgnoredAttributes(List<String> ignoredAttributes);
+
+            RuntimeClasspathNormalization.MetaInf setIgnoredAttributes(String... ignoredAttributes);
+
+            RuntimeClasspathNormalization.MetaInf addIgnoredAttributes(List<String> ignoredAttributes);
+
+            RuntimeClasspathNormalization.MetaInf addIgnoredAttributes(String... ignoredAttributes);
+
+            RuntimeClasspathNormalization.MetaInf setIgnoredProperties(List<String> ignoredProperties);
+
+            RuntimeClasspathNormalization.MetaInf setIgnoredProperties(String... ignoredProperties);
+
+            RuntimeClasspathNormalization.MetaInf addIgnoredProperties(List<String> ignoredProperties);
+
+            RuntimeClasspathNormalization.MetaInf addIgnoredProperties(String... ignoredProperties);
+
+            RuntimeClasspathNormalization.MetaInf setIgnoreManifest(boolean ignoreManifest);
+
+            RuntimeClasspathNormalization.MetaInf setIgnoreCompletely(boolean ignoreCompletely);
+        }
+    }
+
+    interface Context {
+        MavenProject getProject();
+
+        MavenSession getSession();
+
+        Context configureRuntimeClasspathNormalization(Consumer<RuntimeClasspathNormalization> action);
+
+        Context configureSystemPropertiesNormalization(Consumer<SystemPropertiesNormalization> action);
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/NormalizationProviderAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/NormalizationProviderAdapter.java
@@ -7,21 +7,23 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.cache.NormalizationProvider
+ * @see com.gradle.maven.extension.api.cache.NormalizationProvider
+ */
 public interface NormalizationProviderAdapter {
 
     void configureNormalization(Context context);
 
     interface SystemPropertiesNormalization {
         default SystemPropertiesNormalization setIgnoredKeys(String... systemPropertyNames) {
-            setIgnoredKeys(Arrays.asList(systemPropertyNames));
-            return this;
+            return setIgnoredKeys(Arrays.asList(systemPropertyNames));
         }
 
         SystemPropertiesNormalization setIgnoredKeys(List<String> systemPropertyNames);
 
         default SystemPropertiesNormalization addIgnoredKeys(String... systemPropertyNames) {
-            addIgnoredKeys(Arrays.asList(systemPropertyNames));
-            return this;
+            return addIgnoredKeys(Arrays.asList(systemPropertyNames));
         }
 
         SystemPropertiesNormalization addIgnoredKeys(List<String> systemPropertyNames);
@@ -31,22 +33,19 @@ public interface NormalizationProviderAdapter {
         RuntimeClasspathNormalization setIgnoredFiles(List<String> ignoredFiles);
 
         default RuntimeClasspathNormalization setIgnoredFiles(String... ignoredFiles) {
-            setIgnoredFiles(Arrays.asList(ignoredFiles));
-            return this;
+            return setIgnoredFiles(Arrays.asList(ignoredFiles));
         }
 
         RuntimeClasspathNormalization addIgnoredFiles(List<String> ignoredFiles);
 
         default RuntimeClasspathNormalization addIgnoredFiles(String... ignoredFiles) {
-            addIgnoredFiles(Arrays.asList(ignoredFiles));
-            return this;
+            return addIgnoredFiles(Arrays.asList(ignoredFiles));
         }
 
         RuntimeClasspathNormalization addPropertiesNormalization(String path, List<String> ignoredProperties);
 
         default RuntimeClasspathNormalization addPropertiesNormalization(String path, String... ignoredProperties) {
-            addPropertiesNormalization(path, Arrays.asList(ignoredProperties));
-            return this;
+            return addPropertiesNormalization(path, Arrays.asList(ignoredProperties));
         }
 
         RuntimeClasspathNormalization configureMetaInf(Consumer<RuntimeClasspathNormalization.MetaInf> action);
@@ -55,29 +54,25 @@ public interface NormalizationProviderAdapter {
             RuntimeClasspathNormalization.MetaInf setIgnoredAttributes(List<String> ignoredAttributes);
 
             default RuntimeClasspathNormalization.MetaInf setIgnoredAttributes(String... ignoredAttributes) {
-                setIgnoredAttributes(Arrays.asList(ignoredAttributes));
-                return this;
+                return setIgnoredAttributes(Arrays.asList(ignoredAttributes));
             }
 
             RuntimeClasspathNormalization.MetaInf addIgnoredAttributes(List<String> ignoredAttributes);
 
             default RuntimeClasspathNormalization.MetaInf addIgnoredAttributes(String... ignoredAttributes) {
-                addIgnoredAttributes(Arrays.asList(ignoredAttributes));
-                return this;
+                return addIgnoredAttributes(Arrays.asList(ignoredAttributes));
             }
 
             RuntimeClasspathNormalization.MetaInf setIgnoredProperties(List<String> ignoredProperties);
 
             default RuntimeClasspathNormalization.MetaInf setIgnoredProperties(String... ignoredProperties) {
-                setIgnoredProperties(Arrays.asList(ignoredProperties));
-                return this;
+                return setIgnoredProperties(Arrays.asList(ignoredProperties));
             }
 
             RuntimeClasspathNormalization.MetaInf addIgnoredProperties(List<String> ignoredProperties);
 
             default RuntimeClasspathNormalization.MetaInf addIgnoredProperties(String... ignoredProperties) {
-                addIgnoredProperties(Arrays.asList(ignoredProperties));
-                return this;
+                return addIgnoredProperties(Arrays.asList(ignoredProperties));
             }
 
             RuntimeClasspathNormalization.MetaInf setIgnoreManifest(boolean ignoreManifest);

--- a/src/main/java/com/gradle/ccud/adapters/Property.java
+++ b/src/main/java/com/gradle/ccud/adapters/Property.java
@@ -3,12 +3,12 @@ package com.gradle.ccud.adapters;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public final class PropertyConfigurator<T> {
+public final class Property<T> {
 
     private final Consumer<T> setter;
     private final Supplier<T> getter;
 
-    public PropertyConfigurator(Consumer<T> setter, Supplier<T> getter) {
+    public Property(Consumer<T> setter, Supplier<T> getter) {
         this.setter = setter;
         this.getter = getter;
     }

--- a/src/main/java/com/gradle/ccud/adapters/Property.java
+++ b/src/main/java/com/gradle/ccud/adapters/Property.java
@@ -3,14 +3,27 @@ package com.gradle.ccud.adapters;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static com.gradle.ccud.adapters.ReflectionUtils.invokeMethod;
+
 public final class Property<T> {
 
     private final Consumer<T> setter;
     private final Supplier<T> getter;
 
-    public Property(Consumer<T> setter, Supplier<T> getter) {
+    private Property(Consumer<T> setter, Supplier<T> getter) {
         this.setter = setter;
         this.getter = getter;
+    }
+
+    public static <T> Property<T> create(Consumer<T> setter, Supplier<T> getter) {
+        return new Property<>(setter, getter);
+    }
+
+    public static <T> Property<T> optional(Object obj, String setterName, String getterName) {
+        return new Property<>(
+            value -> setIfSupported(obj, setterName, value),
+            () -> getIfSupported(obj, getterName)
+        );
     }
 
     public void set(T value) {
@@ -20,4 +33,14 @@ public final class Property<T> {
     public T get() {
         return getter.get();
     }
+
+    private static <T> void setIfSupported(Object obj, String method, T value) {
+        invokeMethod(obj, method, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getIfSupported(Object obj, String method) {
+        return (T) invokeMethod(obj, method).orElse(null);
+    }
+
 }

--- a/src/main/java/com/gradle/ccud/adapters/Property.java
+++ b/src/main/java/com/gradle/ccud/adapters/Property.java
@@ -40,7 +40,7 @@ public final class Property<T> {
 
     @SuppressWarnings("unchecked")
     private static <T> T getIfSupported(Object obj, String method) {
-        return (T) invokeMethod(obj, method).orElse(null);
+        return (T) invokeMethod(obj, method);
     }
 
 }

--- a/src/main/java/com/gradle/ccud/adapters/PropertyConfigurator.java
+++ b/src/main/java/com/gradle/ccud/adapters/PropertyConfigurator.java
@@ -1,0 +1,23 @@
+package com.gradle.ccud.adapters;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public final class PropertyConfigurator<T> {
+
+    private final Consumer<T> setter;
+    private final Supplier<T> getter;
+
+    public PropertyConfigurator(Consumer<T> setter, Supplier<T> getter) {
+        this.setter = setter;
+        this.getter = getter;
+    }
+
+    public void set(T value) {
+        setter.accept(value);
+    }
+
+    public T get() {
+        return getter.get();
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/PublishedBuildScanAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/PublishedBuildScanAdapter.java
@@ -4,8 +4,36 @@ import java.net.URI;
 
 public interface PublishedBuildScanAdapter {
 
+    static PublishedBuildScanAdapter from(com.gradle.maven.extension.api.scan.PublishedBuildScan scan) {
+        return new DefaultPublishedBuildScanAdapter(scan.getBuildScanId(), scan.getBuildScanUri());
+    }
+
+    static PublishedBuildScanAdapter from(com.gradle.develocity.agent.maven.api.scan.PublishedBuildScan scan) {
+        return new DefaultPublishedBuildScanAdapter(scan.getBuildScanId(), scan.getBuildScanUri());
+    }
+
     String getBuildScanId();
 
     URI getBuildScanUri();
 
+    class DefaultPublishedBuildScanAdapter implements PublishedBuildScanAdapter {
+
+        private final String buildScanId;
+        private final URI buildScanUri;
+
+        private DefaultPublishedBuildScanAdapter(String buildScanId, URI buildScanUri) {
+            this.buildScanId = buildScanId;
+            this.buildScanUri = buildScanUri;
+        }
+
+        @Override
+        public String getBuildScanId() {
+            return buildScanId;
+        }
+
+        @Override
+        public URI getBuildScanUri() {
+            return buildScanUri;
+        }
+    }
 }

--- a/src/main/java/com/gradle/ccud/adapters/PublishedBuildScanAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/PublishedBuildScanAdapter.java
@@ -4,36 +4,7 @@ import java.net.URI;
 
 public interface PublishedBuildScanAdapter {
 
-    static PublishedBuildScanAdapter from(com.gradle.maven.extension.api.scan.PublishedBuildScan scan) {
-        return new DefaultPublishedBuildScanAdapter(scan.getBuildScanId(), scan.getBuildScanUri());
-    }
-
-    static PublishedBuildScanAdapter from(com.gradle.develocity.agent.maven.api.scan.PublishedBuildScan scan) {
-        return new DefaultPublishedBuildScanAdapter(scan.getBuildScanId(), scan.getBuildScanUri());
-    }
-
     String getBuildScanId();
 
     URI getBuildScanUri();
-
-    class DefaultPublishedBuildScanAdapter implements PublishedBuildScanAdapter {
-
-        private final String buildScanId;
-        private final URI buildScanUri;
-
-        private DefaultPublishedBuildScanAdapter(String buildScanId, URI buildScanUri) {
-            this.buildScanId = buildScanId;
-            this.buildScanUri = buildScanUri;
-        }
-
-        @Override
-        public String getBuildScanId() {
-            return buildScanId;
-        }
-
-        @Override
-        public URI getBuildScanUri() {
-            return buildScanUri;
-        }
-    }
 }

--- a/src/main/java/com/gradle/ccud/adapters/PublishedBuildScanAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/PublishedBuildScanAdapter.java
@@ -2,6 +2,10 @@ package com.gradle.ccud.adapters;
 
 import java.net.URI;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.scan.PublishedBuildScan
+ * @see com.gradle.maven.extension.api.scan.PublishedBuildScan
+ */
 public interface PublishedBuildScanAdapter {
 
     String getBuildScanId();

--- a/src/main/java/com/gradle/ccud/adapters/PublishedBuildScanAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/PublishedBuildScanAdapter.java
@@ -1,0 +1,11 @@
+package com.gradle.ccud.adapters;
+
+import java.net.URI;
+
+public interface PublishedBuildScanAdapter {
+
+    String getBuildScanId();
+
+    URI getBuildScanUri();
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/ReflectionUtils.java
+++ b/src/main/java/com/gradle/ccud/adapters/ReflectionUtils.java
@@ -1,6 +1,5 @@
 package com.gradle.ccud.adapters;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Optional;
@@ -25,7 +24,7 @@ public class ReflectionUtils {
 
             warnAboutUnsupportedMethod(method);
             return null;
-        } catch (InvocationTargetException | IllegalAccessException e) {
+        } catch (ReflectiveOperationException e) {
             warnAboutUnsupportedMethod(method);
             return null;
         }

--- a/src/main/java/com/gradle/ccud/adapters/ReflectionUtils.java
+++ b/src/main/java/com/gradle/ccud/adapters/ReflectionUtils.java
@@ -1,0 +1,40 @@
+package com.gradle.ccud.adapters;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.gradle.CommonCustomUserDataDevelocityLogger.LOGGER;
+
+public class ReflectionUtils {
+
+    private ReflectionUtils() {
+    }
+
+    public static Optional<Object> invokeMethod(Object obj, String method, Object... args) {
+        try {
+            Class<?>[] argClasses = Arrays.stream(args).map(Object::getClass).toArray(Class[]::new);
+            return Optional.ofNullable(obj.getClass().getMethod(method, argClasses).invoke(obj, args));
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            warnAboutUnsupportedMethod(method);
+            return Optional.empty();
+        }
+    }
+
+    public static void withMethodSupported(Object obj, String method, Runnable action) {
+        if (isMethodSupported(obj, method)) {
+            action.run();
+        } else {
+            warnAboutUnsupportedMethod(method);
+        }
+    }
+
+    private static boolean isMethodSupported(Object obj, String method) {
+        return Arrays.stream(obj.getClass().getMethods())
+            .anyMatch(it -> it.getName().equals(method));
+    }
+
+    private static void warnAboutUnsupportedMethod(String method) {
+        LOGGER.warn("The '{}' method is not supported by this version of the Develocity extension", method);
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/RemoteBuildCacheAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/RemoteBuildCacheAdapter.java
@@ -1,0 +1,15 @@
+package com.gradle.ccud.adapters;
+
+public interface RemoteBuildCacheAdapter {
+
+    boolean isEnabled();
+
+    void setEnabled(boolean enabled);
+
+    boolean isStoreEnabled();
+
+    void setStoreEnabled(boolean storeEnabled);
+
+    ServerAdapter getServer();
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/RemoteBuildCacheAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/RemoteBuildCacheAdapter.java
@@ -1,5 +1,9 @@
 package com.gradle.ccud.adapters;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.cache.RemoteBuildCache
+ * @see com.gradle.maven.extension.api.cache.RemoteBuildCache
+ */
 public interface RemoteBuildCacheAdapter {
 
     boolean isEnabled();

--- a/src/main/java/com/gradle/ccud/adapters/ServerAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/ServerAdapter.java
@@ -2,6 +2,10 @@ package com.gradle.ccud.adapters;
 
 import java.net.URI;
 
+/**
+ * @see com.gradle.develocity.agent.maven.api.cache.Server
+ * @see com.gradle.maven.extension.api.cache.Server
+ */
 public interface ServerAdapter {
 
     String getServerId();

--- a/src/main/java/com/gradle/ccud/adapters/ServerAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/ServerAdapter.java
@@ -1,0 +1,33 @@
+package com.gradle.ccud.adapters;
+
+import java.net.URI;
+
+public interface ServerAdapter {
+
+    String getServerId();
+
+    void setServerId(String serverId);
+
+    URI getUrl();
+
+    default void setUrl(String url) {
+        this.setUrl(url == null ? null : URI.create(url));
+    }
+
+    void setUrl(URI url);
+
+    boolean isAllowUntrusted();
+
+    void setAllowUntrusted(boolean allowUntrusted);
+
+    boolean isAllowInsecureProtocol();
+
+    void setAllowInsecureProtocol(boolean allowInsecureProtocol);
+
+    boolean isUseExpectContinue();
+
+    void setUseExpectContinue(boolean useExpectContinue);
+
+    CredentialsAdapter getCredentials();
+
+}

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityApiAdapter.java
@@ -1,4 +1,4 @@
-package com.gradle.ccud.adapters.develocity.enterprise;
+package com.gradle.ccud.adapters.develocity;
 
 import com.gradle.ccud.adapters.BuildCacheApiAdapter;
 import com.gradle.ccud.adapters.BuildScanApiAdapter;

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityApiAdapter.java
@@ -89,4 +89,9 @@ public class DevelocityApiAdapter implements DevelocityAdapter {
     public BuildCacheApiAdapter getBuildCache() {
         return buildCache;
     }
+
+    @Override
+    public boolean isDevelocityApi() {
+        return true;
+    }
 }

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityApiAdapter.java
@@ -12,10 +12,12 @@ public class DevelocityApiAdapter implements DevelocityAdapter {
 
     private final DevelocityApi api;
     private final BuildScanApiAdapter buildScan;
+    private final BuildCacheApiAdapter buildCache;
 
     public DevelocityApiAdapter(DevelocityApi api) {
         this.api = api;
         this.buildScan = new DevelocityBuildScanApiAdapter(api.getBuildScan());
+        this.buildCache = new DevelocityBuildCacheApiAdapter(api.getBuildCache());
     }
 
     @Override
@@ -85,7 +87,6 @@ public class DevelocityApiAdapter implements DevelocityAdapter {
 
     @Override
     public BuildCacheApiAdapter getBuildCache() {
-        // TODO pshevche
-        return null;
+        return buildCache;
     }
 }

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityApiAdapter.java
@@ -2,13 +2,13 @@ package com.gradle.ccud.adapters.develocity;
 
 import com.gradle.ccud.adapters.BuildCacheApiAdapter;
 import com.gradle.ccud.adapters.BuildScanApiAdapter;
-import com.gradle.ccud.adapters.DevelocityAdapter;
+import com.gradle.ccud.adapters.CoreApiAdapter;
 import com.gradle.develocity.agent.maven.api.DevelocityApi;
 
 import java.net.URI;
 import java.nio.file.Path;
 
-public class DevelocityApiAdapter implements DevelocityAdapter {
+public class DevelocityApiAdapter implements CoreApiAdapter {
 
     private final DevelocityApi api;
     private final BuildScanApiAdapter buildScan;

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildCacheApiAdapter.java
@@ -1,0 +1,49 @@
+package com.gradle.ccud.adapters.develocity;
+
+import com.gradle.ccud.adapters.BuildCacheApiAdapter;
+import com.gradle.ccud.adapters.LocalBuildCacheAdapter;
+import com.gradle.ccud.adapters.MojoMetadataProviderAdapter;
+import com.gradle.ccud.adapters.NormalizationProviderAdapter;
+import com.gradle.ccud.adapters.RemoteBuildCacheAdapter;
+import com.gradle.develocity.agent.maven.api.cache.BuildCacheApi;
+
+class DevelocityBuildCacheApiAdapter implements BuildCacheApiAdapter {
+
+    private final BuildCacheApi buildCache;
+
+    DevelocityBuildCacheApiAdapter(BuildCacheApi buildCache) {
+        this.buildCache = buildCache;
+    }
+
+    @Override
+    public LocalBuildCacheAdapter getLocal() {
+        // TODO pshevche
+        return null;
+    }
+
+    @Override
+    public RemoteBuildCacheAdapter getRemote() {
+        // TODO pshevche
+        return null;
+    }
+
+    @Override
+    public boolean isRequireClean() {
+        return buildCache.isRequireClean();
+    }
+
+    @Override
+    public void setRequireClean(boolean requireClean) {
+        buildCache.setRequireClean(requireClean);
+    }
+
+    @Override
+    public void registerMojoMetadataProvider(MojoMetadataProviderAdapter metadataProvider) {
+        // TODO pshevche
+    }
+
+    @Override
+    public void registerNormalizationProvider(NormalizationProviderAdapter normalizationProvider) {
+        // TODO pshevche
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildCacheApiAdapter.java
@@ -4,31 +4,68 @@ import com.gradle.ccud.adapters.BuildCacheApiAdapter;
 import com.gradle.ccud.adapters.LocalBuildCacheAdapter;
 import com.gradle.ccud.adapters.MojoMetadataProviderAdapter;
 import com.gradle.ccud.adapters.NormalizationProviderAdapter;
-import com.gradle.ccud.adapters.PropertyConfigurator;
+import com.gradle.ccud.adapters.Property;
 import com.gradle.ccud.adapters.RemoteBuildCacheAdapter;
 import com.gradle.ccud.adapters.shared.DefaultCleanupPolicyAdapter;
+import com.gradle.ccud.adapters.shared.DefaultCredentialsAdapter;
 import com.gradle.ccud.adapters.shared.DefaultLocalBuildCacheAdapter;
+import com.gradle.ccud.adapters.shared.DefaultRemoteBuildCacheAdapter;
+import com.gradle.ccud.adapters.shared.DefaultServerAdapter;
 import com.gradle.develocity.agent.maven.api.cache.BuildCacheApi;
 import com.gradle.develocity.agent.maven.api.cache.CleanupPolicy;
+import com.gradle.develocity.agent.maven.api.cache.Credentials;
 import com.gradle.develocity.agent.maven.api.cache.LocalBuildCache;
+import com.gradle.develocity.agent.maven.api.cache.RemoteBuildCache;
+import com.gradle.develocity.agent.maven.api.cache.Server;
 
 class DevelocityBuildCacheApiAdapter implements BuildCacheApiAdapter {
 
     private final BuildCacheApi buildCache;
     private final LocalBuildCacheAdapter localCache;
+    private final RemoteBuildCacheAdapter remoteCache;
 
     DevelocityBuildCacheApiAdapter(BuildCacheApi buildCache) {
         this.buildCache = buildCache;
+        this.localCache = createLocalCacheAdapter(buildCache);
+        this.remoteCache = createRemoteCacheAdapter(buildCache);
+    }
+
+    private static DefaultLocalBuildCacheAdapter createLocalCacheAdapter(BuildCacheApi buildCache) {
         LocalBuildCache local = buildCache.getLocal();
         CleanupPolicy cleanupPolicy = local.getCleanupPolicy();
-        this.localCache = new DefaultLocalBuildCacheAdapter(
-            new PropertyConfigurator<>(local::setEnabled, local::isEnabled),
-            new PropertyConfigurator<>(local::setStoreEnabled, local::isStoreEnabled),
-            new PropertyConfigurator<>(local::setDirectory, local::getDirectory),
+        return new DefaultLocalBuildCacheAdapter(
+            new Property<>(local::setEnabled, local::isEnabled),
+            new Property<>(local::setStoreEnabled, local::isStoreEnabled),
+            new Property<>(local::setDirectory, local::getDirectory),
             new DefaultCleanupPolicyAdapter(
-                new PropertyConfigurator<>(cleanupPolicy::setEnabled, cleanupPolicy::isEnabled),
-                new PropertyConfigurator<>(cleanupPolicy::setRetentionPeriod, cleanupPolicy::getRetentionPeriod),
-                new PropertyConfigurator<>(cleanupPolicy::setCleanupInterval, cleanupPolicy::getCleanupInterval)
+                new Property<>(cleanupPolicy::setEnabled, cleanupPolicy::isEnabled),
+                new Property<>(cleanupPolicy::setRetentionPeriod, cleanupPolicy::getRetentionPeriod),
+                new Property<>(cleanupPolicy::setCleanupInterval, cleanupPolicy::getCleanupInterval)
+            )
+        );
+    }
+
+    private static DefaultRemoteBuildCacheAdapter createRemoteCacheAdapter(BuildCacheApi buildCache) {
+        RemoteBuildCache remote = buildCache.getRemote();
+        Server server = remote.getServer();
+        return new DefaultRemoteBuildCacheAdapter(
+            new Property<>(remote::setEnabled, remote::isEnabled),
+            new Property<>(remote::setStoreEnabled, remote::isStoreEnabled),
+            createServerAdapter(server)
+        );
+    }
+
+    private static DefaultServerAdapter createServerAdapter(Server server) {
+        Credentials credentials = server.getCredentials();
+        return new DefaultServerAdapter(
+            new Property<>(server::setServerId, server::getServerId),
+            new Property<>(server::setUrl, server::getUrl),
+            new Property<>(server::setAllowUntrusted, server::isAllowUntrusted),
+            new Property<>(server::setAllowInsecureProtocol, server::isAllowInsecureProtocol),
+            new Property<>(server::setUseExpectContinue, server::isUseExpectContinue),
+            new DefaultCredentialsAdapter(
+                new Property<>(credentials::setUsername, credentials::getUsername),
+                new Property<>(credentials::setPassword, credentials::getPassword)
             )
         );
     }
@@ -40,8 +77,7 @@ class DevelocityBuildCacheApiAdapter implements BuildCacheApiAdapter {
 
     @Override
     public RemoteBuildCacheAdapter getRemote() {
-        // TODO pshevche
-        return null;
+        return remoteCache;
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildCacheApiAdapter.java
@@ -97,6 +97,6 @@ class DevelocityBuildCacheApiAdapter implements BuildCacheApiAdapter {
 
     @Override
     public void registerNormalizationProvider(NormalizationProviderAdapter normalizationProvider) {
-        // TODO pshevche
+        buildCache.registerNormalizationProvider(ctx -> normalizationProvider.configureNormalization(new DevelocityNormalizationContext(ctx)));
     }
 }

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildCacheApiAdapter.java
@@ -4,21 +4,38 @@ import com.gradle.ccud.adapters.BuildCacheApiAdapter;
 import com.gradle.ccud.adapters.LocalBuildCacheAdapter;
 import com.gradle.ccud.adapters.MojoMetadataProviderAdapter;
 import com.gradle.ccud.adapters.NormalizationProviderAdapter;
+import com.gradle.ccud.adapters.PropertyConfigurator;
 import com.gradle.ccud.adapters.RemoteBuildCacheAdapter;
+import com.gradle.ccud.adapters.shared.DefaultCleanupPolicyAdapter;
+import com.gradle.ccud.adapters.shared.DefaultLocalBuildCacheAdapter;
 import com.gradle.develocity.agent.maven.api.cache.BuildCacheApi;
+import com.gradle.develocity.agent.maven.api.cache.CleanupPolicy;
+import com.gradle.develocity.agent.maven.api.cache.LocalBuildCache;
 
 class DevelocityBuildCacheApiAdapter implements BuildCacheApiAdapter {
 
     private final BuildCacheApi buildCache;
+    private final LocalBuildCacheAdapter localCache;
 
     DevelocityBuildCacheApiAdapter(BuildCacheApi buildCache) {
         this.buildCache = buildCache;
+        LocalBuildCache local = buildCache.getLocal();
+        CleanupPolicy cleanupPolicy = local.getCleanupPolicy();
+        this.localCache = new DefaultLocalBuildCacheAdapter(
+            new PropertyConfigurator<>(local::setEnabled, local::isEnabled),
+            new PropertyConfigurator<>(local::setStoreEnabled, local::isStoreEnabled),
+            new PropertyConfigurator<>(local::setDirectory, local::getDirectory),
+            new DefaultCleanupPolicyAdapter(
+                new PropertyConfigurator<>(cleanupPolicy::setEnabled, cleanupPolicy::isEnabled),
+                new PropertyConfigurator<>(cleanupPolicy::setRetentionPeriod, cleanupPolicy::getRetentionPeriod),
+                new PropertyConfigurator<>(cleanupPolicy::setCleanupInterval, cleanupPolicy::getCleanupInterval)
+            )
+        );
     }
 
     @Override
     public LocalBuildCacheAdapter getLocal() {
-        // TODO pshevche
-        return null;
+        return localCache;
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildCacheApiAdapter.java
@@ -34,13 +34,13 @@ class DevelocityBuildCacheApiAdapter implements BuildCacheApiAdapter {
         LocalBuildCache local = buildCache.getLocal();
         CleanupPolicy cleanupPolicy = local.getCleanupPolicy();
         return new DefaultLocalBuildCacheAdapter(
-            new Property<>(local::setEnabled, local::isEnabled),
-            new Property<>(local::setStoreEnabled, local::isStoreEnabled),
-            new Property<>(local::setDirectory, local::getDirectory),
+            Property.create(local::setEnabled, local::isEnabled),
+            Property.create(local::setStoreEnabled, local::isStoreEnabled),
+            Property.create(local::setDirectory, local::getDirectory),
             new DefaultCleanupPolicyAdapter(
-                new Property<>(cleanupPolicy::setEnabled, cleanupPolicy::isEnabled),
-                new Property<>(cleanupPolicy::setRetentionPeriod, cleanupPolicy::getRetentionPeriod),
-                new Property<>(cleanupPolicy::setCleanupInterval, cleanupPolicy::getCleanupInterval)
+                Property.create(cleanupPolicy::setEnabled, cleanupPolicy::isEnabled),
+                Property.create(cleanupPolicy::setRetentionPeriod, cleanupPolicy::getRetentionPeriod),
+                Property.create(cleanupPolicy::setCleanupInterval, cleanupPolicy::getCleanupInterval)
             )
         );
     }
@@ -49,8 +49,8 @@ class DevelocityBuildCacheApiAdapter implements BuildCacheApiAdapter {
         RemoteBuildCache remote = buildCache.getRemote();
         Server server = remote.getServer();
         return new DefaultRemoteBuildCacheAdapter(
-            new Property<>(remote::setEnabled, remote::isEnabled),
-            new Property<>(remote::setStoreEnabled, remote::isStoreEnabled),
+            Property.create(remote::setEnabled, remote::isEnabled),
+            Property.create(remote::setStoreEnabled, remote::isStoreEnabled),
             createServerAdapter(server)
         );
     }
@@ -58,14 +58,14 @@ class DevelocityBuildCacheApiAdapter implements BuildCacheApiAdapter {
     private static DefaultServerAdapter createServerAdapter(Server server) {
         Credentials credentials = server.getCredentials();
         return new DefaultServerAdapter(
-            new Property<>(server::setServerId, server::getServerId),
-            new Property<>(server::setUrl, server::getUrl),
-            new Property<>(server::setAllowUntrusted, server::isAllowUntrusted),
-            new Property<>(server::setAllowInsecureProtocol, server::isAllowInsecureProtocol),
-            new Property<>(server::setUseExpectContinue, server::isUseExpectContinue),
+            Property.create(server::setServerId, server::getServerId),
+            Property.create(server::setUrl, server::getUrl),
+            Property.create(server::setAllowUntrusted, server::isAllowUntrusted),
+            Property.create(server::setAllowInsecureProtocol, server::isAllowInsecureProtocol),
+            Property.create(server::setUseExpectContinue, server::isUseExpectContinue),
             new DefaultCredentialsAdapter(
-                new Property<>(credentials::setUsername, credentials::getUsername),
-                new Property<>(credentials::setPassword, credentials::getPassword)
+                Property.create(credentials::setUsername, credentials::getUsername),
+                Property.create(credentials::setPassword, credentials::getPassword)
             )
         );
     }

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildCacheApiAdapter.java
@@ -92,7 +92,7 @@ class DevelocityBuildCacheApiAdapter implements BuildCacheApiAdapter {
 
     @Override
     public void registerMojoMetadataProvider(MojoMetadataProviderAdapter metadataProvider) {
-        // TODO pshevche
+        buildCache.registerMojoMetadataProvider(ctx -> metadataProvider.provideMetadata(new DevelocityMojoMetadataContext(ctx)));
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildScanApiAdapter.java
@@ -6,6 +6,7 @@ import com.gradle.ccud.adapters.BuildScanCaptureAdapter;
 import com.gradle.ccud.adapters.BuildScanDataObfuscationAdapter;
 import com.gradle.ccud.adapters.PublishedBuildScanAdapter;
 import com.gradle.ccud.adapters.shared.DefaultBuildResultAdapter;
+import com.gradle.ccud.adapters.shared.DefaultBuildScanDataObfuscationAdapter;
 import com.gradle.ccud.adapters.shared.DefaultPublishedBuildScanAdapter;
 import com.gradle.develocity.agent.maven.api.scan.BuildScanApi;
 
@@ -15,9 +16,15 @@ import java.util.function.Consumer;
 class DevelocityBuildScanApiAdapter implements BuildScanApiAdapter {
 
     private final BuildScanApi buildScan;
+    private final BuildScanDataObfuscationAdapter obfuscation;
 
     DevelocityBuildScanApiAdapter(BuildScanApi buildScan) {
         this.buildScan = buildScan;
+        this.obfuscation = new DefaultBuildScanDataObfuscationAdapter(
+            buildScan.getObfuscation()::username,
+            buildScan.getObfuscation()::hostname,
+            buildScan.getObfuscation()::ipAddresses
+        );
     }
 
     @Override
@@ -132,12 +139,7 @@ class DevelocityBuildScanApiAdapter implements BuildScanApiAdapter {
 
     @Override
     public BuildScanDataObfuscationAdapter getObfuscation() {
-        return null;
-    }
-
-    @Override
-    public void obfuscation(Consumer<? super BuildScanDataObfuscationAdapter> action) {
-
+        return obfuscation;
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildScanApiAdapter.java
@@ -4,7 +4,7 @@ import com.gradle.ccud.adapters.BuildResultAdapter;
 import com.gradle.ccud.adapters.BuildScanApiAdapter;
 import com.gradle.ccud.adapters.BuildScanCaptureAdapter;
 import com.gradle.ccud.adapters.BuildScanDataObfuscationAdapter;
-import com.gradle.ccud.adapters.PropertyConfigurator;
+import com.gradle.ccud.adapters.Property;
 import com.gradle.ccud.adapters.PublishedBuildScanAdapter;
 import com.gradle.ccud.adapters.shared.DefaultBuildResultAdapter;
 import com.gradle.ccud.adapters.shared.DefaultBuildScanCaptureAdapter;
@@ -29,9 +29,9 @@ class DevelocityBuildScanApiAdapter implements BuildScanApiAdapter {
             buildScan.getObfuscation()::ipAddresses
         );
         this.capture = new DefaultBuildScanCaptureAdapter(
-            new PropertyConfigurator<>(buildScan.getCapture()::setFileFingerprints, buildScan.getCapture()::isFileFingerprints),
-            new PropertyConfigurator<>(buildScan.getCapture()::setBuildLogging, buildScan.getCapture()::isBuildLogging),
-            new PropertyConfigurator<>(buildScan.getCapture()::setTestLogging, buildScan.getCapture()::isTestLogging)
+            new Property<>(buildScan.getCapture()::setFileFingerprints, buildScan.getCapture()::isFileFingerprints),
+            new Property<>(buildScan.getCapture()::setBuildLogging, buildScan.getCapture()::isBuildLogging),
+            new Property<>(buildScan.getCapture()::setTestLogging, buildScan.getCapture()::isTestLogging)
         );
     }
 

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildScanApiAdapter.java
@@ -1,10 +1,12 @@
-package com.gradle.ccud.adapters.develocity.enterprise;
+package com.gradle.ccud.adapters.develocity;
 
 import com.gradle.ccud.adapters.BuildResultAdapter;
 import com.gradle.ccud.adapters.BuildScanApiAdapter;
 import com.gradle.ccud.adapters.BuildScanCaptureAdapter;
 import com.gradle.ccud.adapters.BuildScanDataObfuscationAdapter;
 import com.gradle.ccud.adapters.PublishedBuildScanAdapter;
+import com.gradle.ccud.adapters.shared.DefaultBuildResultAdapter;
+import com.gradle.ccud.adapters.shared.DefaultPublishedBuildScanAdapter;
 import com.gradle.develocity.agent.maven.api.scan.BuildScanApi;
 
 import java.net.URI;
@@ -40,12 +42,12 @@ class DevelocityBuildScanApiAdapter implements BuildScanApiAdapter {
 
     @Override
     public void buildFinished(Consumer<? super BuildResultAdapter> action) {
-        buildScan.buildFinished(result -> action.accept(BuildResultAdapter.from(result)));
+        buildScan.buildFinished(result -> action.accept(new DefaultBuildResultAdapter(result.getFailures())));
     }
 
     @Override
     public void buildScanPublished(Consumer<? super PublishedBuildScanAdapter> action) {
-        buildScan.buildScanPublished(scan -> action.accept(PublishedBuildScanAdapter.from(scan)));
+        buildScan.buildScanPublished(scan -> action.accept(new DefaultPublishedBuildScanAdapter(scan.getBuildScanId(), scan.getBuildScanUri())));
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildScanApiAdapter.java
@@ -4,8 +4,10 @@ import com.gradle.ccud.adapters.BuildResultAdapter;
 import com.gradle.ccud.adapters.BuildScanApiAdapter;
 import com.gradle.ccud.adapters.BuildScanCaptureAdapter;
 import com.gradle.ccud.adapters.BuildScanDataObfuscationAdapter;
+import com.gradle.ccud.adapters.PropertyConfigurator;
 import com.gradle.ccud.adapters.PublishedBuildScanAdapter;
 import com.gradle.ccud.adapters.shared.DefaultBuildResultAdapter;
+import com.gradle.ccud.adapters.shared.DefaultBuildScanCaptureAdapter;
 import com.gradle.ccud.adapters.shared.DefaultBuildScanDataObfuscationAdapter;
 import com.gradle.ccud.adapters.shared.DefaultPublishedBuildScanAdapter;
 import com.gradle.develocity.agent.maven.api.scan.BuildScanApi;
@@ -17,6 +19,7 @@ class DevelocityBuildScanApiAdapter implements BuildScanApiAdapter {
 
     private final BuildScanApi buildScan;
     private final BuildScanDataObfuscationAdapter obfuscation;
+    private final BuildScanCaptureAdapter capture;
 
     DevelocityBuildScanApiAdapter(BuildScanApi buildScan) {
         this.buildScan = buildScan;
@@ -24,6 +27,11 @@ class DevelocityBuildScanApiAdapter implements BuildScanApiAdapter {
             buildScan.getObfuscation()::username,
             buildScan.getObfuscation()::hostname,
             buildScan.getObfuscation()::ipAddresses
+        );
+        this.capture = new DefaultBuildScanCaptureAdapter(
+            new PropertyConfigurator<>(buildScan.getCapture()::setFileFingerprints, buildScan.getCapture()::isFileFingerprints),
+            new PropertyConfigurator<>(buildScan.getCapture()::setBuildLogging, buildScan.getCapture()::isBuildLogging),
+            new PropertyConfigurator<>(buildScan.getCapture()::setTestLogging, buildScan.getCapture()::isTestLogging)
         );
     }
 
@@ -144,11 +152,7 @@ class DevelocityBuildScanApiAdapter implements BuildScanApiAdapter {
 
     @Override
     public BuildScanCaptureAdapter getCapture() {
-        return null;
+        return capture;
     }
 
-    @Override
-    public void capture(Consumer<? super BuildScanCaptureAdapter> action) {
-
-    }
 }

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildScanApiAdapter.java
@@ -29,9 +29,9 @@ class DevelocityBuildScanApiAdapter implements BuildScanApiAdapter {
             buildScan.getObfuscation()::ipAddresses
         );
         this.capture = new DefaultBuildScanCaptureAdapter(
-            new Property<>(buildScan.getCapture()::setFileFingerprints, buildScan.getCapture()::isFileFingerprints),
-            new Property<>(buildScan.getCapture()::setBuildLogging, buildScan.getCapture()::isBuildLogging),
-            new Property<>(buildScan.getCapture()::setTestLogging, buildScan.getCapture()::isTestLogging)
+            Property.create(buildScan.getCapture()::setFileFingerprints, buildScan.getCapture()::isFileFingerprints),
+            Property.create(buildScan.getCapture()::setBuildLogging, buildScan.getCapture()::isBuildLogging),
+            Property.create(buildScan.getCapture()::setTestLogging, buildScan.getCapture()::isTestLogging)
         );
     }
 

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityMojoMetadataContext.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityMojoMetadataContext.java
@@ -62,7 +62,7 @@ class DevelocityMojoMetadataContext implements MojoMetadataProviderAdapter.Conte
     @Override
     public MojoMetadataProviderAdapter.Context localState(Consumer<? super MojoMetadataProviderAdapter.Context.LocalState> action) {
         ctx.localState(state -> action.accept(new LocalState(state)));
-        return null;
+        return this;
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityMojoMetadataContext.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityMojoMetadataContext.java
@@ -1,0 +1,241 @@
+package com.gradle.ccud.adapters.develocity;
+
+import com.gradle.ccud.adapters.MojoMetadataProviderAdapter;
+import com.gradle.develocity.agent.maven.api.cache.MojoMetadataProvider;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+class DevelocityMojoMetadataContext implements MojoMetadataProviderAdapter.Context {
+    private final MojoMetadataProvider.Context ctx;
+
+    DevelocityMojoMetadataContext(MojoMetadataProvider.Context ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public Object getUnderlyingObject() {
+        return ctx.getUnderlyingObject();
+    }
+
+    @Override
+    public MojoExecution getMojoExecution() {
+        return ctx.getMojoExecution();
+    }
+
+    @Override
+    public MavenProject getProject() {
+        return ctx.getProject();
+    }
+
+    @Override
+    public MavenSession getSession() {
+        return ctx.getSession();
+    }
+
+    @Override
+    public void withPlugin(String artifactId, Runnable action) {
+        ctx.withPlugin(artifactId, action);
+    }
+
+    @Override
+    public MojoMetadataProviderAdapter.Context skipIfTrue(List<String> propertyNames) {
+        ctx.skipIfTrue(propertyNames);
+        return this;
+    }
+
+    @Override
+    public MojoMetadataProviderAdapter.Context inputs(Consumer<? super MojoMetadataProviderAdapter.Context.Inputs> action) {
+        ctx.inputs(inputs -> action.accept(new Inputs(inputs)));
+        return this;
+    }
+
+    @Override
+    public MojoMetadataProviderAdapter.Context outputs(Consumer<? super MojoMetadataProviderAdapter.Context.Outputs> action) {
+        ctx.outputs(outputs -> action.accept(new Outputs(outputs)));
+        return this;
+    }
+
+    @Override
+    public MojoMetadataProviderAdapter.Context localState(Consumer<? super MojoMetadataProviderAdapter.Context.LocalState> action) {
+        ctx.localState(state -> action.accept(new LocalState(state)));
+        return null;
+    }
+
+    @Override
+    public MojoMetadataProviderAdapter.Context nested(String propertyName, Consumer<? super MojoMetadataProviderAdapter.Context> action) {
+        ctx.nested(propertyName, ctx -> action.accept(new DevelocityMojoMetadataContext(ctx)));
+        return this;
+    }
+
+    @Override
+    public MojoMetadataProviderAdapter.Context iterate(String propertyName, Consumer<? super MojoMetadataProviderAdapter.Context> action) {
+        ctx.iterate(propertyName, ctx -> action.accept(new DevelocityMojoMetadataContext(ctx)));
+        return this;
+    }
+
+    private static class Inputs implements MojoMetadataProviderAdapter.Context.Inputs {
+
+        private final MojoMetadataProvider.Context.Inputs inputs;
+
+        private Inputs(MojoMetadataProvider.Context.Inputs inputs) {
+            this.inputs = inputs;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Inputs properties(String... propertyNames) {
+            inputs.properties(propertyNames);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Inputs property(String propertyName, Object value) {
+            inputs.property(propertyName, value);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Inputs fileSet(String propertyName, Consumer<MojoMetadataProviderAdapter.Context.FileSet> action) {
+            inputs.fileSet(propertyName, fileSet -> action.accept(new FileSet(fileSet)));
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Inputs fileSet(String propertyName, Object files, Consumer<MojoMetadataProviderAdapter.Context.FileSet> action) {
+            inputs.fileSet(propertyName, files, fileSet -> action.accept(new FileSet(fileSet)));
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Inputs ignore(String... propertyNames) {
+            inputs.ignore(propertyNames);
+            return this;
+        }
+    }
+
+    private static class Outputs implements MojoMetadataProviderAdapter.Context.Outputs {
+
+        private final MojoMetadataProvider.Context.Outputs outputs;
+
+        private Outputs(MojoMetadataProvider.Context.Outputs outputs) {
+            this.outputs = outputs;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs file(String propertyName) {
+            outputs.file(propertyName);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs file(String propertyName, Object file) {
+            outputs.file(propertyName, file);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs directory(String propertyName) {
+            outputs.directory(propertyName);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs directory(String propertyName, Object directory) {
+            outputs.directory(propertyName, directory);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs cacheable(String reason) {
+            outputs.cacheable(reason);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs notCacheableBecause(String reason) {
+            outputs.notCacheableBecause(reason);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs storeEnabled(boolean enabled) {
+            outputs.storeEnabled(enabled);
+            return this;
+        }
+    }
+
+    private static class LocalState implements MojoMetadataProviderAdapter.Context.LocalState {
+
+        private final MojoMetadataProvider.Context.LocalState state;
+
+        private LocalState(MojoMetadataProvider.Context.LocalState state) {
+            this.state = state;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.LocalState files(String propertyName) {
+            state.files(propertyName);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.LocalState files(String propertyName, Object value) {
+            state.files(propertyName, value);
+            return this;
+        }
+    }
+
+    private static class FileSet implements MojoMetadataProviderAdapter.Context.FileSet {
+
+        private final MojoMetadataProvider.Context.FileSet fileSet;
+
+        private FileSet(MojoMetadataProvider.Context.FileSet fileSet) {
+            this.fileSet = fileSet;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet includesProperty(String includePropertyName) {
+            fileSet.includesProperty(includePropertyName);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet include(List<String> includePatterns) {
+            fileSet.include(includePatterns);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet excludesProperty(String excludePropertyName) {
+            fileSet.excludesProperty(excludePropertyName);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet exclude(List<String> excludePatterns) {
+            fileSet.exclude(excludePatterns);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet normalizationStrategy(NormalizationStrategy normalizationStrategy) {
+            fileSet.normalizationStrategy(MojoMetadataProvider.Context.FileSet.NormalizationStrategy.valueOf(normalizationStrategy.name()));
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet emptyDirectoryHandling(EmptyDirectoryHandling emptyDirectoryHandling) {
+            fileSet.emptyDirectoryHandling(MojoMetadataProvider.Context.FileSet.EmptyDirectoryHandling.valueOf(emptyDirectoryHandling.name()));
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet lineEndingHandling(LineEndingHandling lineEndingHandling) {
+            fileSet.lineEndingHandling(MojoMetadataProvider.Context.FileSet.LineEndingHandling.valueOf(lineEndingHandling.name()));
+            return this;
+        }
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityNormalizationContext.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityNormalizationContext.java
@@ -33,7 +33,8 @@ class DevelocityNormalizationContext implements NormalizationProviderAdapter.Con
 
     @Override
     public NormalizationProviderAdapter.Context configureSystemPropertiesNormalization(Consumer<NormalizationProviderAdapter.SystemPropertiesNormalization> action) {
-        return null;
+        ctx.configureSystemPropertiesNormalization(normalization -> action.accept(new SystemPropertiesNormalization(normalization)));
+        return this;
     }
 
     private static class RuntimeClasspathNormalization implements NormalizationProviderAdapter.RuntimeClasspathNormalization {
@@ -111,6 +112,26 @@ class DevelocityNormalizationContext implements NormalizationProviderAdapter.Con
                 metaInf.setIgnoreCompletely(ignoreCompletely);
                 return this;
             }
+        }
+    }
+
+    private static class SystemPropertiesNormalization implements NormalizationProviderAdapter.SystemPropertiesNormalization {
+        private final NormalizationProvider.SystemPropertiesNormalization normalization;
+
+        private SystemPropertiesNormalization(NormalizationProvider.SystemPropertiesNormalization normalization) {
+            this.normalization = normalization;
+        }
+
+        @Override
+        public NormalizationProviderAdapter.SystemPropertiesNormalization setIgnoredKeys(List<String> systemPropertyNames) {
+            normalization.setIgnoredKeys(systemPropertyNames);
+            return this;
+        }
+
+        @Override
+        public NormalizationProviderAdapter.SystemPropertiesNormalization addIgnoredKeys(List<String> systemPropertyNames) {
+            normalization.addIgnoredKeys(systemPropertyNames);
+            return this;
         }
     }
 }

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityNormalizationContext.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityNormalizationContext.java
@@ -1,0 +1,116 @@
+package com.gradle.ccud.adapters.develocity;
+
+import com.gradle.ccud.adapters.NormalizationProviderAdapter;
+import com.gradle.develocity.agent.maven.api.cache.NormalizationProvider;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+class DevelocityNormalizationContext implements NormalizationProviderAdapter.Context {
+    private final NormalizationProvider.Context ctx;
+
+    DevelocityNormalizationContext(NormalizationProvider.Context ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public MavenProject getProject() {
+        return ctx.getProject();
+    }
+
+    @Override
+    public MavenSession getSession() {
+        return ctx.getSession();
+    }
+
+    @Override
+    public NormalizationProviderAdapter.Context configureRuntimeClasspathNormalization(Consumer<NormalizationProviderAdapter.RuntimeClasspathNormalization> action) {
+        ctx.configureRuntimeClasspathNormalization(normalization -> action.accept(new RuntimeClasspathNormalization(normalization)));
+        return this;
+    }
+
+    @Override
+    public NormalizationProviderAdapter.Context configureSystemPropertiesNormalization(Consumer<NormalizationProviderAdapter.SystemPropertiesNormalization> action) {
+        return null;
+    }
+
+    private static class RuntimeClasspathNormalization implements NormalizationProviderAdapter.RuntimeClasspathNormalization {
+
+        private final NormalizationProvider.RuntimeClasspathNormalization normalization;
+
+        private RuntimeClasspathNormalization(NormalizationProvider.RuntimeClasspathNormalization normalization) {
+            this.normalization = normalization;
+        }
+
+        @Override
+        public NormalizationProviderAdapter.RuntimeClasspathNormalization setIgnoredFiles(List<String> ignoredFiles) {
+            normalization.setIgnoredFiles(ignoredFiles);
+            return this;
+        }
+
+        @Override
+        public NormalizationProviderAdapter.RuntimeClasspathNormalization addIgnoredFiles(List<String> ignoredFiles) {
+            normalization.addIgnoredFiles(ignoredFiles);
+            return this;
+        }
+
+        @Override
+        public NormalizationProviderAdapter.RuntimeClasspathNormalization addPropertiesNormalization(String path, List<String> ignoredProperties) {
+            normalization.addPropertiesNormalization(path, ignoredProperties);
+            return this;
+        }
+
+        @Override
+        public NormalizationProviderAdapter.RuntimeClasspathNormalization configureMetaInf(Consumer<NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf> action) {
+            normalization.configureMetaInf(metaInf -> action.accept(new MetaInf(metaInf)));
+            return this;
+        }
+
+        private static class MetaInf implements NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf {
+
+            private final NormalizationProvider.RuntimeClasspathNormalization.MetaInf metaInf;
+
+            MetaInf(NormalizationProvider.RuntimeClasspathNormalization.MetaInf metaInf) {
+                this.metaInf = metaInf;
+            }
+
+            @Override
+            public NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf setIgnoredAttributes(List<String> ignoredAttributes) {
+                metaInf.setIgnoredAttributes(ignoredAttributes);
+                return this;
+            }
+
+            @Override
+            public NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf addIgnoredAttributes(List<String> ignoredAttributes) {
+                metaInf.addIgnoredAttributes(ignoredAttributes);
+                return this;
+            }
+
+            @Override
+            public NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf setIgnoredProperties(List<String> ignoredProperties) {
+                metaInf.setIgnoredProperties(ignoredProperties);
+                return this;
+            }
+
+            @Override
+            public NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf addIgnoredProperties(List<String> ignoredProperties) {
+                metaInf.addIgnoredProperties(ignoredProperties);
+                return this;
+            }
+
+            @Override
+            public NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf setIgnoreManifest(boolean ignoreManifest) {
+                metaInf.setIgnoreManifest(ignoreManifest);
+                return this;
+            }
+
+            @Override
+            public NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf setIgnoreCompletely(boolean ignoreCompletely) {
+                metaInf.setIgnoreCompletely(ignoreCompletely);
+                return this;
+            }
+        }
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/develocity/enterprise/DevelocityApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/enterprise/DevelocityApiAdapter.java
@@ -1,0 +1,88 @@
+package com.gradle.ccud.adapters.develocity.enterprise;
+
+import com.gradle.ccud.adapters.BuildCacheApiAdapter;
+import com.gradle.ccud.adapters.BuildScanApiAdapter;
+import com.gradle.ccud.adapters.DevelocityAdapter;
+import com.gradle.develocity.agent.maven.api.DevelocityApi;
+
+import java.net.URI;
+import java.nio.file.Path;
+
+public class DevelocityApiAdapter implements DevelocityAdapter {
+
+    private final DevelocityApi api;
+
+    public DevelocityApiAdapter(DevelocityApi api) {
+        this.api = api;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return api.isEnabled();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        api.setEnabled(enabled);
+    }
+
+    @Override
+    public void setProjectId(String projectId) {
+        api.setProjectId(projectId);
+    }
+
+    @Override
+    public String getProjectId() {
+        return api.getProjectId();
+    }
+
+    @Override
+    public Path getStorageDirectory() {
+        return api.getStorageDirectory();
+    }
+
+    @Override
+    public void setStorageDirectory(Path path) {
+        api.setStorageDirectory(path);
+    }
+
+    @Override
+    public void setServer(URI url) {
+        api.setServer(url);
+    }
+
+    @Override
+    public String getServer() {
+        return api.getServer();
+    }
+
+    @Override
+    public void setAllowUntrustedServer(boolean allow) {
+        api.setAllowUntrustedServer(allow);
+    }
+
+    @Override
+    public boolean getAllowUntrustedServer() {
+        return api.getAllowUntrustedServer();
+    }
+
+    @Override
+    public void setAccessKey(String accessKey) {
+        api.setAccessKey(accessKey);
+    }
+
+    @Override
+    public String getAccessKey() {
+        return api.getAccessKey();
+    }
+
+    @Override
+    public BuildScanApiAdapter getBuildScan() {
+        return null;
+    }
+
+    @Override
+    public BuildCacheApiAdapter getBuildCache() {
+        return null;
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/develocity/enterprise/DevelocityApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/enterprise/DevelocityApiAdapter.java
@@ -11,9 +11,11 @@ import java.nio.file.Path;
 public class DevelocityApiAdapter implements DevelocityAdapter {
 
     private final DevelocityApi api;
+    private final BuildScanApiAdapter buildScan;
 
     public DevelocityApiAdapter(DevelocityApi api) {
         this.api = api;
+        this.buildScan = new DevelocityBuildScanApiAdapter(api.getBuildScan());
     }
 
     @Override
@@ -78,11 +80,12 @@ public class DevelocityApiAdapter implements DevelocityAdapter {
 
     @Override
     public BuildScanApiAdapter getBuildScan() {
-        return null;
+        return buildScan;
     }
 
     @Override
     public BuildCacheApiAdapter getBuildCache() {
+        // TODO pshevche
         return null;
     }
 }

--- a/src/main/java/com/gradle/ccud/adapters/develocity/enterprise/DevelocityBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/enterprise/DevelocityBuildScanApiAdapter.java
@@ -1,0 +1,150 @@
+package com.gradle.ccud.adapters.develocity.enterprise;
+
+import com.gradle.ccud.adapters.BuildResultAdapter;
+import com.gradle.ccud.adapters.BuildScanApiAdapter;
+import com.gradle.ccud.adapters.BuildScanCaptureAdapter;
+import com.gradle.ccud.adapters.BuildScanDataObfuscationAdapter;
+import com.gradle.ccud.adapters.PublishedBuildScanAdapter;
+import com.gradle.develocity.agent.maven.api.scan.BuildScanApi;
+
+import java.net.URI;
+import java.util.function.Consumer;
+
+class DevelocityBuildScanApiAdapter implements BuildScanApiAdapter {
+
+    private final BuildScanApi buildScan;
+
+    DevelocityBuildScanApiAdapter(BuildScanApi buildScan) {
+        this.buildScan = buildScan;
+    }
+
+    @Override
+    public void tag(String tag) {
+        buildScan.tag(tag);
+    }
+
+    @Override
+    public void value(String name, String value) {
+        buildScan.value(name, value);
+    }
+
+    @Override
+    public void link(String name, String url) {
+        buildScan.link(name, url);
+    }
+
+    @Override
+    public void background(Consumer<? super BuildScanApiAdapter> action) {
+        buildScan.background(__ -> action.accept(this));
+    }
+
+    @Override
+    public void buildFinished(Consumer<? super BuildResultAdapter> action) {
+        buildScan.buildFinished(result -> action.accept(BuildResultAdapter.from(result)));
+    }
+
+    @Override
+    public void buildScanPublished(Consumer<? super PublishedBuildScanAdapter> action) {
+        buildScan.buildScanPublished(scan -> action.accept(PublishedBuildScanAdapter.from(scan)));
+    }
+
+    @Override
+    public void setTermsOfServiceUrl(String termsOfServiceUrl) {
+        buildScan.setTermsOfServiceUrl(termsOfServiceUrl);
+    }
+
+    @Override
+    public String getTermsOfServiceUrl() {
+        return buildScan.getTermsOfServiceUrl();
+    }
+
+    @Override
+    public void setTermsOfServiceAgree(String agree) {
+        buildScan.setTermsOfServiceAgree(agree);
+    }
+
+    @Override
+    public String getTermsOfServiceAgree() {
+        return buildScan.getTermsOfServiceAgree();
+    }
+
+    @Override
+    public void setServer(URI url) {
+        buildScan.setServer(url);
+    }
+
+    @Override
+    public String getServer() {
+        return buildScan.getServer();
+    }
+
+    @Override
+    public void setAllowUntrustedServer(boolean allow) {
+        buildScan.setAllowUntrustedServer(allow);
+    }
+
+    @Override
+    public boolean getAllowUntrustedServer() {
+        return buildScan.getAllowUntrustedServer();
+    }
+
+    @Override
+    public void publishAlways() {
+        buildScan.publishing(p -> p.onlyIf(ctx -> true));
+    }
+
+    @Override
+    public void publishAlwaysIf(boolean condition) {
+        buildScan.publishing(p -> p.onlyIf(ctx -> condition));
+    }
+
+    @Override
+    public void publishOnFailure() {
+        buildScan.publishing(p -> p.onlyIf(ctx -> !ctx.getBuildResult().getFailures().isEmpty()));
+    }
+
+    @Override
+    public void publishOnFailureIf(boolean condition) {
+        buildScan.publishing(p -> p.onlyIf(ctx -> !ctx.getBuildResult().getFailures().isEmpty() && condition));
+    }
+
+    @Override
+    public void publishOnDemand() {
+        // on-demand publication in the new API is controlled only via -Dscan property
+    }
+
+    @Override
+    public void setUploadInBackground(boolean uploadInBackground) {
+        buildScan.setUploadInBackground(uploadInBackground);
+    }
+
+    @Override
+    public boolean isUploadInBackground() {
+        return buildScan.isUploadInBackground();
+    }
+
+    @Override
+    public void executeOnce(String identifier, Consumer<? super BuildScanApiAdapter> action) {
+        buildScan.executeOnce(identifier, __ -> action.accept(this));
+    }
+
+    @Override
+    public BuildScanDataObfuscationAdapter getObfuscation() {
+        return null;
+    }
+
+    @Override
+    public void obfuscation(Consumer<? super BuildScanDataObfuscationAdapter> action) {
+
+    }
+
+    @Override
+    public BuildScanCaptureAdapter getCapture() {
+        return null;
+    }
+
+    @Override
+    public void capture(Consumer<? super BuildScanCaptureAdapter> action) {
+
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseApiAdapter.java
@@ -3,6 +3,7 @@ package com.gradle.ccud.adapters.enterprise;
 import com.gradle.ccud.adapters.BuildCacheApiAdapter;
 import com.gradle.ccud.adapters.BuildScanApiAdapter;
 import com.gradle.ccud.adapters.DevelocityAdapter;
+import com.gradle.ccud.adapters.Property;
 import com.gradle.maven.extension.api.GradleEnterpriseApi;
 
 import java.net.URI;
@@ -13,11 +14,13 @@ public class GradleEnterpriseApiAdapter implements DevelocityAdapter {
     private final GradleEnterpriseApi api;
     private final BuildScanApiAdapter buildScan;
     private final BuildCacheApiAdapter buildCache;
+    private final Property<String> projectId;
 
     public GradleEnterpriseApiAdapter(GradleEnterpriseApi api) {
         this.api = api;
         this.buildScan = new GradleEnterpriseBuildScanApiAdapter(api.getBuildScan());
         this.buildCache = new GradleEnterpriseBuildCacheApiAdapter(api.getBuildCache());
+        this.projectId = Property.optional(api, "setProjectId", "getProjectId");
     }
 
     @Override
@@ -32,12 +35,12 @@ public class GradleEnterpriseApiAdapter implements DevelocityAdapter {
 
     @Override
     public void setProjectId(String projectId) {
-        api.setProjectId(projectId);
+        this.projectId.set(projectId);
     }
 
     @Override
     public String getProjectId() {
-        return api.getProjectId();
+        return projectId.get();
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseApiAdapter.java
@@ -2,14 +2,14 @@ package com.gradle.ccud.adapters.enterprise;
 
 import com.gradle.ccud.adapters.BuildCacheApiAdapter;
 import com.gradle.ccud.adapters.BuildScanApiAdapter;
-import com.gradle.ccud.adapters.DevelocityAdapter;
+import com.gradle.ccud.adapters.CoreApiAdapter;
 import com.gradle.ccud.adapters.Property;
 import com.gradle.maven.extension.api.GradleEnterpriseApi;
 
 import java.net.URI;
 import java.nio.file.Path;
 
-public class GradleEnterpriseApiAdapter implements DevelocityAdapter {
+public class GradleEnterpriseApiAdapter implements CoreApiAdapter {
 
     private final GradleEnterpriseApi api;
     private final BuildScanApiAdapter buildScan;

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseApiAdapter.java
@@ -12,10 +12,12 @@ public class GradleEnterpriseApiAdapter implements DevelocityAdapter {
 
     private final GradleEnterpriseApi api;
     private final BuildScanApiAdapter buildScan;
+    private final BuildCacheApiAdapter buildCache;
 
     public GradleEnterpriseApiAdapter(GradleEnterpriseApi api) {
         this.api = api;
         this.buildScan = new GradleEnterpriseBuildScanApiAdapter(api.getBuildScan());
+        this.buildCache = new GradleEnterpriseBuildCacheApiAdapter(api.getBuildCache());
     }
 
     @Override
@@ -85,7 +87,6 @@ public class GradleEnterpriseApiAdapter implements DevelocityAdapter {
 
     @Override
     public BuildCacheApiAdapter getBuildCache() {
-        // TODO pshevche
-        return null;
+        return buildCache;
     }
 }

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseApiAdapter.java
@@ -11,9 +11,11 @@ import java.nio.file.Path;
 public class GradleEnterpriseApiAdapter implements DevelocityAdapter {
 
     private final GradleEnterpriseApi api;
+    private final BuildScanApiAdapter buildScan;
 
     public GradleEnterpriseApiAdapter(GradleEnterpriseApi api) {
         this.api = api;
+        this.buildScan = new GradleEnterpriseBuildScanApiAdapter(api.getBuildScan());
     }
 
     @Override
@@ -78,11 +80,12 @@ public class GradleEnterpriseApiAdapter implements DevelocityAdapter {
 
     @Override
     public BuildScanApiAdapter getBuildScan() {
-        return null;
+        return buildScan;
     }
 
     @Override
     public BuildCacheApiAdapter getBuildCache() {
+        // TODO pshevche
         return null;
     }
 }

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseApiAdapter.java
@@ -1,0 +1,88 @@
+package com.gradle.ccud.adapters.enterprise;
+
+import com.gradle.ccud.adapters.BuildCacheApiAdapter;
+import com.gradle.ccud.adapters.BuildScanApiAdapter;
+import com.gradle.ccud.adapters.DevelocityAdapter;
+import com.gradle.maven.extension.api.GradleEnterpriseApi;
+
+import java.net.URI;
+import java.nio.file.Path;
+
+public class GradleEnterpriseApiAdapter implements DevelocityAdapter {
+
+    private final GradleEnterpriseApi api;
+
+    public GradleEnterpriseApiAdapter(GradleEnterpriseApi api) {
+        this.api = api;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return api.isEnabled();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        api.setEnabled(enabled);
+    }
+
+    @Override
+    public void setProjectId(String projectId) {
+        api.setProjectId(projectId);
+    }
+
+    @Override
+    public String getProjectId() {
+        return api.getProjectId();
+    }
+
+    @Override
+    public Path getStorageDirectory() {
+        return api.getStorageDirectory();
+    }
+
+    @Override
+    public void setStorageDirectory(Path path) {
+        api.setStorageDirectory(path);
+    }
+
+    @Override
+    public void setServer(URI url) {
+        api.setServer(url);
+    }
+
+    @Override
+    public String getServer() {
+        return api.getServer();
+    }
+
+    @Override
+    public void setAllowUntrustedServer(boolean allow) {
+        api.setAllowUntrustedServer(allow);
+    }
+
+    @Override
+    public boolean getAllowUntrustedServer() {
+        return api.getAllowUntrustedServer();
+    }
+
+    @Override
+    public void setAccessKey(String accessKey) {
+        api.setAccessKey(accessKey);
+    }
+
+    @Override
+    public String getAccessKey() {
+        return api.getAccessKey();
+    }
+
+    @Override
+    public BuildScanApiAdapter getBuildScan() {
+        return null;
+    }
+
+    @Override
+    public BuildCacheApiAdapter getBuildCache() {
+        return null;
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseApiAdapter.java
@@ -89,4 +89,9 @@ public class GradleEnterpriseApiAdapter implements DevelocityAdapter {
     public BuildCacheApiAdapter getBuildCache() {
         return buildCache;
     }
+
+    @Override
+    public boolean isDevelocityApi() {
+        return false;
+    }
 }

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildCacheApiAdapter.java
@@ -97,6 +97,6 @@ class GradleEnterpriseBuildCacheApiAdapter implements BuildCacheApiAdapter {
 
     @Override
     public void registerNormalizationProvider(NormalizationProviderAdapter normalizationProvider) {
-        // TODO pshevche
+        buildCache.registerNormalizationProvider(ctx -> normalizationProvider.configureNormalization(new GradleEnterpriseNormalizationContext(ctx)));
     }
 }

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildCacheApiAdapter.java
@@ -4,32 +4,68 @@ import com.gradle.ccud.adapters.BuildCacheApiAdapter;
 import com.gradle.ccud.adapters.LocalBuildCacheAdapter;
 import com.gradle.ccud.adapters.MojoMetadataProviderAdapter;
 import com.gradle.ccud.adapters.NormalizationProviderAdapter;
-import com.gradle.ccud.adapters.PropertyConfigurator;
+import com.gradle.ccud.adapters.Property;
 import com.gradle.ccud.adapters.RemoteBuildCacheAdapter;
 import com.gradle.ccud.adapters.shared.DefaultCleanupPolicyAdapter;
+import com.gradle.ccud.adapters.shared.DefaultCredentialsAdapter;
 import com.gradle.ccud.adapters.shared.DefaultLocalBuildCacheAdapter;
+import com.gradle.ccud.adapters.shared.DefaultRemoteBuildCacheAdapter;
+import com.gradle.ccud.adapters.shared.DefaultServerAdapter;
 import com.gradle.maven.extension.api.cache.BuildCacheApi;
 import com.gradle.maven.extension.api.cache.CleanupPolicy;
+import com.gradle.maven.extension.api.cache.Credentials;
 import com.gradle.maven.extension.api.cache.LocalBuildCache;
+import com.gradle.maven.extension.api.cache.RemoteBuildCache;
+import com.gradle.maven.extension.api.cache.Server;
 
 class GradleEnterpriseBuildCacheApiAdapter implements BuildCacheApiAdapter {
 
     private final BuildCacheApi buildCache;
     private final LocalBuildCacheAdapter localCache;
+    private final RemoteBuildCacheAdapter remoteCache;
 
     GradleEnterpriseBuildCacheApiAdapter(BuildCacheApi buildCache) {
         this.buildCache = buildCache;
+        this.localCache = createLocalCacheAdapter(buildCache);
+        this.remoteCache = createRemoteCacheAdapter(buildCache);
+    }
 
+    private static DefaultLocalBuildCacheAdapter createLocalCacheAdapter(BuildCacheApi buildCache) {
         LocalBuildCache local = buildCache.getLocal();
         CleanupPolicy cleanupPolicy = local.getCleanupPolicy();
-        this.localCache = new DefaultLocalBuildCacheAdapter(
-            new PropertyConfigurator<>(local::setEnabled, local::isEnabled),
-            new PropertyConfigurator<>(local::setStoreEnabled, local::isStoreEnabled),
-            new PropertyConfigurator<>(local::setDirectory, local::getDirectory),
+        return new DefaultLocalBuildCacheAdapter(
+            new Property<>(local::setEnabled, local::isEnabled),
+            new Property<>(local::setStoreEnabled, local::isStoreEnabled),
+            new Property<>(local::setDirectory, local::getDirectory),
             new DefaultCleanupPolicyAdapter(
-                new PropertyConfigurator<>(cleanupPolicy::setEnabled, cleanupPolicy::isEnabled),
-                new PropertyConfigurator<>(cleanupPolicy::setRetentionPeriod, cleanupPolicy::getRetentionPeriod),
-                new PropertyConfigurator<>(cleanupPolicy::setCleanupInterval, cleanupPolicy::getCleanupInterval)
+                new Property<>(cleanupPolicy::setEnabled, cleanupPolicy::isEnabled),
+                new Property<>(cleanupPolicy::setRetentionPeriod, cleanupPolicy::getRetentionPeriod),
+                new Property<>(cleanupPolicy::setCleanupInterval, cleanupPolicy::getCleanupInterval)
+            )
+        );
+    }
+
+    private static DefaultRemoteBuildCacheAdapter createRemoteCacheAdapter(BuildCacheApi buildCache) {
+        RemoteBuildCache remote = buildCache.getRemote();
+        Server server = remote.getServer();
+        return new DefaultRemoteBuildCacheAdapter(
+            new Property<>(remote::setEnabled, remote::isEnabled),
+            new Property<>(remote::setStoreEnabled, remote::isStoreEnabled),
+            createServerAdapter(server)
+        );
+    }
+
+    private static DefaultServerAdapter createServerAdapter(Server server) {
+        Credentials credentials = server.getCredentials();
+        return new DefaultServerAdapter(
+            new Property<>(server::setServerId, server::getServerId),
+            new Property<>(server::setUrl, server::getUrl),
+            new Property<>(server::setAllowUntrusted, server::isAllowUntrusted),
+            new Property<>(server::setAllowInsecureProtocol, server::isAllowInsecureProtocol),
+            new Property<>(server::setUseExpectContinue, server::isUseExpectContinue),
+            new DefaultCredentialsAdapter(
+                new Property<>(credentials::setUsername, credentials::getUsername),
+                new Property<>(credentials::setPassword, credentials::getPassword)
             )
         );
     }
@@ -41,8 +77,7 @@ class GradleEnterpriseBuildCacheApiAdapter implements BuildCacheApiAdapter {
 
     @Override
     public RemoteBuildCacheAdapter getRemote() {
-        // TODO pshevche
-        return null;
+        return remoteCache;
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildCacheApiAdapter.java
@@ -92,7 +92,7 @@ class GradleEnterpriseBuildCacheApiAdapter implements BuildCacheApiAdapter {
 
     @Override
     public void registerMojoMetadataProvider(MojoMetadataProviderAdapter metadataProvider) {
-        // TODO pshevche
+        buildCache.registerMojoMetadataProvider(ctx -> metadataProvider.provideMetadata(new GradleEnterpriseMojoMetadataContext(ctx)));
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildCacheApiAdapter.java
@@ -1,0 +1,49 @@
+package com.gradle.ccud.adapters.enterprise;
+
+import com.gradle.ccud.adapters.BuildCacheApiAdapter;
+import com.gradle.ccud.adapters.LocalBuildCacheAdapter;
+import com.gradle.ccud.adapters.MojoMetadataProviderAdapter;
+import com.gradle.ccud.adapters.NormalizationProviderAdapter;
+import com.gradle.ccud.adapters.RemoteBuildCacheAdapter;
+import com.gradle.maven.extension.api.cache.BuildCacheApi;
+
+class GradleEnterpriseBuildCacheApiAdapter implements BuildCacheApiAdapter {
+
+    private final BuildCacheApi buildCache;
+
+    GradleEnterpriseBuildCacheApiAdapter(BuildCacheApi buildCache) {
+        this.buildCache = buildCache;
+    }
+
+    @Override
+    public LocalBuildCacheAdapter getLocal() {
+        // TODO pshevche
+        return null;
+    }
+
+    @Override
+    public RemoteBuildCacheAdapter getRemote() {
+        // TODO pshevche
+        return null;
+    }
+
+    @Override
+    public boolean isRequireClean() {
+        return buildCache.isRequireClean();
+    }
+
+    @Override
+    public void setRequireClean(boolean requireClean) {
+        buildCache.setRequireClean(requireClean);
+    }
+
+    @Override
+    public void registerMojoMetadataProvider(MojoMetadataProviderAdapter metadataProvider) {
+        // TODO pshevche
+    }
+
+    @Override
+    public void registerNormalizationProvider(NormalizationProviderAdapter normalizationProvider) {
+        // TODO pshevche
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildCacheApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildCacheApiAdapter.java
@@ -4,21 +4,39 @@ import com.gradle.ccud.adapters.BuildCacheApiAdapter;
 import com.gradle.ccud.adapters.LocalBuildCacheAdapter;
 import com.gradle.ccud.adapters.MojoMetadataProviderAdapter;
 import com.gradle.ccud.adapters.NormalizationProviderAdapter;
+import com.gradle.ccud.adapters.PropertyConfigurator;
 import com.gradle.ccud.adapters.RemoteBuildCacheAdapter;
+import com.gradle.ccud.adapters.shared.DefaultCleanupPolicyAdapter;
+import com.gradle.ccud.adapters.shared.DefaultLocalBuildCacheAdapter;
 import com.gradle.maven.extension.api.cache.BuildCacheApi;
+import com.gradle.maven.extension.api.cache.CleanupPolicy;
+import com.gradle.maven.extension.api.cache.LocalBuildCache;
 
 class GradleEnterpriseBuildCacheApiAdapter implements BuildCacheApiAdapter {
 
     private final BuildCacheApi buildCache;
+    private final LocalBuildCacheAdapter localCache;
 
     GradleEnterpriseBuildCacheApiAdapter(BuildCacheApi buildCache) {
         this.buildCache = buildCache;
+
+        LocalBuildCache local = buildCache.getLocal();
+        CleanupPolicy cleanupPolicy = local.getCleanupPolicy();
+        this.localCache = new DefaultLocalBuildCacheAdapter(
+            new PropertyConfigurator<>(local::setEnabled, local::isEnabled),
+            new PropertyConfigurator<>(local::setStoreEnabled, local::isStoreEnabled),
+            new PropertyConfigurator<>(local::setDirectory, local::getDirectory),
+            new DefaultCleanupPolicyAdapter(
+                new PropertyConfigurator<>(cleanupPolicy::setEnabled, cleanupPolicy::isEnabled),
+                new PropertyConfigurator<>(cleanupPolicy::setRetentionPeriod, cleanupPolicy::getRetentionPeriod),
+                new PropertyConfigurator<>(cleanupPolicy::setCleanupInterval, cleanupPolicy::getCleanupInterval)
+            )
+        );
     }
 
     @Override
     public LocalBuildCacheAdapter getLocal() {
-        // TODO pshevche
-        return null;
+        return localCache;
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
@@ -29,9 +29,9 @@ class GradleEnterpriseBuildScanApiAdapter implements BuildScanApiAdapter {
             buildScan.getObfuscation()::ipAddresses
         );
         this.capture = new DefaultBuildScanCaptureAdapter(
-            new Property<>(buildScan.getCapture()::setGoalInputFiles, buildScan.getCapture()::isGoalInputFiles),
-            new Property<>(buildScan.getCapture()::setBuildLogging, buildScan.getCapture()::isBuildLogging),
-            new Property<>(buildScan.getCapture()::setTestLogging, buildScan.getCapture()::isTestLogging)
+            Property.create(buildScan.getCapture()::setGoalInputFiles, buildScan.getCapture()::isGoalInputFiles),
+            Property.create(buildScan.getCapture()::setBuildLogging, buildScan.getCapture()::isBuildLogging),
+            Property.create(buildScan.getCapture()::setTestLogging, buildScan.getCapture()::isTestLogging)
         );
     }
 

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
@@ -4,7 +4,7 @@ import com.gradle.ccud.adapters.BuildResultAdapter;
 import com.gradle.ccud.adapters.BuildScanApiAdapter;
 import com.gradle.ccud.adapters.BuildScanCaptureAdapter;
 import com.gradle.ccud.adapters.BuildScanDataObfuscationAdapter;
-import com.gradle.ccud.adapters.PropertyConfigurator;
+import com.gradle.ccud.adapters.Property;
 import com.gradle.ccud.adapters.PublishedBuildScanAdapter;
 import com.gradle.ccud.adapters.shared.DefaultBuildResultAdapter;
 import com.gradle.ccud.adapters.shared.DefaultBuildScanCaptureAdapter;
@@ -29,9 +29,9 @@ class GradleEnterpriseBuildScanApiAdapter implements BuildScanApiAdapter {
             buildScan.getObfuscation()::ipAddresses
         );
         this.capture = new DefaultBuildScanCaptureAdapter(
-            new PropertyConfigurator<>(buildScan.getCapture()::setGoalInputFiles, buildScan.getCapture()::isGoalInputFiles),
-            new PropertyConfigurator<>(buildScan.getCapture()::setBuildLogging, buildScan.getCapture()::isBuildLogging),
-            new PropertyConfigurator<>(buildScan.getCapture()::setTestLogging, buildScan.getCapture()::isTestLogging)
+            new Property<>(buildScan.getCapture()::setGoalInputFiles, buildScan.getCapture()::isGoalInputFiles),
+            new Property<>(buildScan.getCapture()::setBuildLogging, buildScan.getCapture()::isBuildLogging),
+            new Property<>(buildScan.getCapture()::setTestLogging, buildScan.getCapture()::isTestLogging)
         );
     }
 

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
@@ -4,8 +4,10 @@ import com.gradle.ccud.adapters.BuildResultAdapter;
 import com.gradle.ccud.adapters.BuildScanApiAdapter;
 import com.gradle.ccud.adapters.BuildScanCaptureAdapter;
 import com.gradle.ccud.adapters.BuildScanDataObfuscationAdapter;
+import com.gradle.ccud.adapters.PropertyConfigurator;
 import com.gradle.ccud.adapters.PublishedBuildScanAdapter;
 import com.gradle.ccud.adapters.shared.DefaultBuildResultAdapter;
+import com.gradle.ccud.adapters.shared.DefaultBuildScanCaptureAdapter;
 import com.gradle.ccud.adapters.shared.DefaultBuildScanDataObfuscationAdapter;
 import com.gradle.ccud.adapters.shared.DefaultPublishedBuildScanAdapter;
 import com.gradle.maven.extension.api.scan.BuildScanApi;
@@ -17,6 +19,7 @@ class GradleEnterpriseBuildScanApiAdapter implements BuildScanApiAdapter {
 
     private final BuildScanApi buildScan;
     private final BuildScanDataObfuscationAdapter obfuscation;
+    private final BuildScanCaptureAdapter capture;
 
     GradleEnterpriseBuildScanApiAdapter(BuildScanApi buildScan) {
         this.buildScan = buildScan;
@@ -24,6 +27,11 @@ class GradleEnterpriseBuildScanApiAdapter implements BuildScanApiAdapter {
             buildScan.getObfuscation()::username,
             buildScan.getObfuscation()::hostname,
             buildScan.getObfuscation()::ipAddresses
+        );
+        this.capture = new DefaultBuildScanCaptureAdapter(
+            new PropertyConfigurator<>(buildScan.getCapture()::setGoalInputFiles, buildScan.getCapture()::isGoalInputFiles),
+            new PropertyConfigurator<>(buildScan.getCapture()::setBuildLogging, buildScan.getCapture()::isBuildLogging),
+            new PropertyConfigurator<>(buildScan.getCapture()::setTestLogging, buildScan.getCapture()::isTestLogging)
         );
     }
 
@@ -144,12 +152,6 @@ class GradleEnterpriseBuildScanApiAdapter implements BuildScanApiAdapter {
 
     @Override
     public BuildScanCaptureAdapter getCapture() {
-        // TODO pshevche
-        return null;
-    }
-
-    @Override
-    public void capture(Consumer<? super BuildScanCaptureAdapter> action) {
-        // TODO pshevche
+        return capture;
     }
 }

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
@@ -5,6 +5,8 @@ import com.gradle.ccud.adapters.BuildScanApiAdapter;
 import com.gradle.ccud.adapters.BuildScanCaptureAdapter;
 import com.gradle.ccud.adapters.BuildScanDataObfuscationAdapter;
 import com.gradle.ccud.adapters.PublishedBuildScanAdapter;
+import com.gradle.ccud.adapters.shared.DefaultBuildResultAdapter;
+import com.gradle.ccud.adapters.shared.DefaultPublishedBuildScanAdapter;
 import com.gradle.maven.extension.api.scan.BuildScanApi;
 
 import java.net.URI;
@@ -40,12 +42,12 @@ class GradleEnterpriseBuildScanApiAdapter implements BuildScanApiAdapter {
 
     @Override
     public void buildFinished(Consumer<? super BuildResultAdapter> action) {
-        buildScan.buildFinished(result -> action.accept(BuildResultAdapter.from(result)));
+        buildScan.buildFinished(result -> action.accept(new DefaultBuildResultAdapter(result.getFailures())));
     }
 
     @Override
     public void buildScanPublished(Consumer<? super PublishedBuildScanAdapter> action) {
-        buildScan.buildScanPublished(scan -> action.accept(PublishedBuildScanAdapter.from(scan)));
+        buildScan.buildScanPublished(scan -> action.accept(new DefaultPublishedBuildScanAdapter(scan.getBuildScanId(), scan.getBuildScanUri())));
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
@@ -6,6 +6,7 @@ import com.gradle.ccud.adapters.BuildScanCaptureAdapter;
 import com.gradle.ccud.adapters.BuildScanDataObfuscationAdapter;
 import com.gradle.ccud.adapters.PublishedBuildScanAdapter;
 import com.gradle.ccud.adapters.shared.DefaultBuildResultAdapter;
+import com.gradle.ccud.adapters.shared.DefaultBuildScanDataObfuscationAdapter;
 import com.gradle.ccud.adapters.shared.DefaultPublishedBuildScanAdapter;
 import com.gradle.maven.extension.api.scan.BuildScanApi;
 
@@ -15,9 +16,15 @@ import java.util.function.Consumer;
 class GradleEnterpriseBuildScanApiAdapter implements BuildScanApiAdapter {
 
     private final BuildScanApi buildScan;
+    private final BuildScanDataObfuscationAdapter obfuscation;
 
     GradleEnterpriseBuildScanApiAdapter(BuildScanApi buildScan) {
         this.buildScan = buildScan;
+        this.obfuscation = new DefaultBuildScanDataObfuscationAdapter(
+            buildScan.getObfuscation()::username,
+            buildScan.getObfuscation()::hostname,
+            buildScan.getObfuscation()::ipAddresses
+        );
     }
 
     @Override
@@ -132,13 +139,7 @@ class GradleEnterpriseBuildScanApiAdapter implements BuildScanApiAdapter {
 
     @Override
     public BuildScanDataObfuscationAdapter getObfuscation() {
-        // TODO pshevche
-        return null;
-    }
-
-    @Override
-    public void obfuscation(Consumer<? super BuildScanDataObfuscationAdapter> action) {
-        // TODO pshevche
+        return obfuscation;
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
@@ -1,0 +1,152 @@
+package com.gradle.ccud.adapters.enterprise;
+
+import com.gradle.ccud.adapters.BuildResultAdapter;
+import com.gradle.ccud.adapters.BuildScanApiAdapter;
+import com.gradle.ccud.adapters.BuildScanCaptureAdapter;
+import com.gradle.ccud.adapters.BuildScanDataObfuscationAdapter;
+import com.gradle.ccud.adapters.PublishedBuildScanAdapter;
+import com.gradle.maven.extension.api.scan.BuildScanApi;
+
+import java.net.URI;
+import java.util.function.Consumer;
+
+class GradleEnterpriseBuildScanApiAdapter implements BuildScanApiAdapter {
+
+    private final BuildScanApi buildScan;
+
+    GradleEnterpriseBuildScanApiAdapter(BuildScanApi buildScan) {
+        this.buildScan = buildScan;
+    }
+
+    @Override
+    public void tag(String tag) {
+        buildScan.tag(tag);
+    }
+
+    @Override
+    public void value(String name, String value) {
+        buildScan.value(name, value);
+    }
+
+    @Override
+    public void link(String name, String url) {
+        buildScan.link(name, url);
+    }
+
+    @Override
+    public void background(Consumer<? super BuildScanApiAdapter> action) {
+        buildScan.background(__ -> action.accept(this));
+    }
+
+    @Override
+    public void buildFinished(Consumer<? super BuildResultAdapter> action) {
+        buildScan.buildFinished(result -> action.accept(BuildResultAdapter.from(result)));
+    }
+
+    @Override
+    public void buildScanPublished(Consumer<? super PublishedBuildScanAdapter> action) {
+        buildScan.buildScanPublished(scan -> action.accept(PublishedBuildScanAdapter.from(scan)));
+    }
+
+    @Override
+    public void setTermsOfServiceUrl(String termsOfServiceUrl) {
+        buildScan.setTermsOfServiceUrl(termsOfServiceUrl);
+    }
+
+    @Override
+    public String getTermsOfServiceUrl() {
+        return buildScan.getTermsOfServiceUrl();
+    }
+
+    @Override
+    public void setTermsOfServiceAgree(String agree) {
+        buildScan.setTermsOfServiceAgree(agree);
+    }
+
+    @Override
+    public String getTermsOfServiceAgree() {
+        return buildScan.getTermsOfServiceAgree();
+    }
+
+    @Override
+    public void setServer(URI url) {
+        buildScan.setServer(url);
+    }
+
+    @Override
+    public String getServer() {
+        return buildScan.getServer();
+    }
+
+    @Override
+    public void setAllowUntrustedServer(boolean allow) {
+        buildScan.setAllowUntrustedServer(allow);
+    }
+
+    @Override
+    public boolean getAllowUntrustedServer() {
+        return buildScan.getAllowUntrustedServer();
+    }
+
+    @Override
+    public void publishAlways() {
+        buildScan.publishAlways();
+    }
+
+    @Override
+    public void publishAlwaysIf(boolean condition) {
+        buildScan.publishAlwaysIf(condition);
+    }
+
+    @Override
+    public void publishOnFailure() {
+        buildScan.publishOnFailure();
+    }
+
+    @Override
+    public void publishOnFailureIf(boolean condition) {
+        buildScan.publishOnFailureIf(condition);
+    }
+
+    @Override
+    public void publishOnDemand() {
+        buildScan.publishOnDemand();
+    }
+
+    @Override
+    public void setUploadInBackground(boolean uploadInBackground) {
+        buildScan.setUploadInBackground(uploadInBackground);
+    }
+
+    @Override
+    public boolean isUploadInBackground() {
+        return buildScan.isUploadInBackground();
+    }
+
+    @Override
+    public void executeOnce(String identifier, Consumer<? super BuildScanApiAdapter> action) {
+        buildScan.executeOnce(identifier, __ -> action.accept(this));
+    }
+
+    @Override
+    public BuildScanDataObfuscationAdapter getObfuscation() {
+        // TODO pshevche
+        return null;
+    }
+
+    @Override
+    public void obfuscation(Consumer<? super BuildScanDataObfuscationAdapter> action) {
+        // TODO pshevche
+    }
+
+    @Override
+    public BuildScanCaptureAdapter getCapture() {
+        // TODO pshevche
+        return null;
+    }
+
+    @Override
+    public void capture(Consumer<? super BuildScanCaptureAdapter> action) {
+        // TODO pshevche
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseMojoMetadataContext.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseMojoMetadataContext.java
@@ -1,0 +1,241 @@
+package com.gradle.ccud.adapters.enterprise;
+
+import com.gradle.ccud.adapters.MojoMetadataProviderAdapter;
+import com.gradle.maven.extension.api.cache.MojoMetadataProvider;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+class GradleEnterpriseMojoMetadataContext implements MojoMetadataProviderAdapter.Context {
+    private final MojoMetadataProvider.Context ctx;
+
+    GradleEnterpriseMojoMetadataContext(MojoMetadataProvider.Context ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public Object getUnderlyingObject() {
+        return ctx.getUnderlyingObject();
+    }
+
+    @Override
+    public MojoExecution getMojoExecution() {
+        return ctx.getMojoExecution();
+    }
+
+    @Override
+    public MavenProject getProject() {
+        return ctx.getProject();
+    }
+
+    @Override
+    public MavenSession getSession() {
+        return ctx.getSession();
+    }
+
+    @Override
+    public void withPlugin(String artifactId, Runnable action) {
+        ctx.withPlugin(artifactId, action);
+    }
+
+    @Override
+    public MojoMetadataProviderAdapter.Context skipIfTrue(List<String> propertyNames) {
+        ctx.skipIfTrue(propertyNames);
+        return this;
+    }
+
+    @Override
+    public MojoMetadataProviderAdapter.Context inputs(Consumer<? super MojoMetadataProviderAdapter.Context.Inputs> action) {
+        ctx.inputs(inputs -> action.accept(new Inputs(inputs)));
+        return this;
+    }
+
+    @Override
+    public MojoMetadataProviderAdapter.Context outputs(Consumer<? super MojoMetadataProviderAdapter.Context.Outputs> action) {
+        ctx.outputs(outputs -> action.accept(new Outputs(outputs)));
+        return this;
+    }
+
+    @Override
+    public MojoMetadataProviderAdapter.Context localState(Consumer<? super MojoMetadataProviderAdapter.Context.LocalState> action) {
+        ctx.localState(state -> action.accept(new LocalState(state)));
+        return null;
+    }
+
+    @Override
+    public MojoMetadataProviderAdapter.Context nested(String propertyName, Consumer<? super MojoMetadataProviderAdapter.Context> action) {
+        ctx.nested(propertyName, ctx -> action.accept(new GradleEnterpriseMojoMetadataContext(ctx)));
+        return this;
+    }
+
+    @Override
+    public MojoMetadataProviderAdapter.Context iterate(String propertyName, Consumer<? super MojoMetadataProviderAdapter.Context> action) {
+        ctx.iterate(propertyName, ctx -> action.accept(new GradleEnterpriseMojoMetadataContext(ctx)));
+        return this;
+    }
+
+    private static class Inputs implements MojoMetadataProviderAdapter.Context.Inputs {
+
+        private final MojoMetadataProvider.Context.Inputs inputs;
+
+        private Inputs(MojoMetadataProvider.Context.Inputs inputs) {
+            this.inputs = inputs;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Inputs properties(String... propertyNames) {
+            inputs.properties(propertyNames);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Inputs property(String propertyName, Object value) {
+            inputs.property(propertyName, value);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Inputs fileSet(String propertyName, Consumer<MojoMetadataProviderAdapter.Context.FileSet> action) {
+            inputs.fileSet(propertyName, fileSet -> action.accept(new FileSet(fileSet)));
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Inputs fileSet(String propertyName, Object files, Consumer<MojoMetadataProviderAdapter.Context.FileSet> action) {
+            inputs.fileSet(propertyName, files, fileSet -> action.accept(new FileSet(fileSet)));
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Inputs ignore(String... propertyNames) {
+            inputs.ignore(propertyNames);
+            return this;
+        }
+    }
+
+    private static class Outputs implements MojoMetadataProviderAdapter.Context.Outputs {
+
+        private final MojoMetadataProvider.Context.Outputs outputs;
+
+        private Outputs(MojoMetadataProvider.Context.Outputs outputs) {
+            this.outputs = outputs;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs file(String propertyName) {
+            outputs.file(propertyName);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs file(String propertyName, Object file) {
+            outputs.file(propertyName, file);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs directory(String propertyName) {
+            outputs.directory(propertyName);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs directory(String propertyName, Object directory) {
+            outputs.directory(propertyName, directory);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs cacheable(String reason) {
+            outputs.cacheable(reason);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs notCacheableBecause(String reason) {
+            outputs.notCacheableBecause(reason);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.Outputs storeEnabled(boolean enabled) {
+            outputs.storeEnabled(enabled);
+            return this;
+        }
+    }
+
+    private static class LocalState implements MojoMetadataProviderAdapter.Context.LocalState {
+
+        private final MojoMetadataProvider.Context.LocalState state;
+
+        private LocalState(MojoMetadataProvider.Context.LocalState state) {
+            this.state = state;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.LocalState files(String propertyName) {
+            state.files(propertyName);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.LocalState files(String propertyName, Object value) {
+            state.files(propertyName, value);
+            return this;
+        }
+    }
+
+    private static class FileSet implements MojoMetadataProviderAdapter.Context.FileSet {
+
+        private final MojoMetadataProvider.Context.FileSet fileSet;
+
+        private FileSet(MojoMetadataProvider.Context.FileSet fileSet) {
+            this.fileSet = fileSet;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet includesProperty(String includePropertyName) {
+            fileSet.includesProperty(includePropertyName);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet include(List<String> includePatterns) {
+            fileSet.include(includePatterns);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet excludesProperty(String excludePropertyName) {
+            fileSet.excludesProperty(excludePropertyName);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet exclude(List<String> excludePatterns) {
+            fileSet.exclude(excludePatterns);
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet normalizationStrategy(NormalizationStrategy normalizationStrategy) {
+            fileSet.normalizationStrategy(MojoMetadataProvider.Context.FileSet.NormalizationStrategy.valueOf(normalizationStrategy.name()));
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet emptyDirectoryHandling(EmptyDirectoryHandling emptyDirectoryHandling) {
+            fileSet.emptyDirectoryHandling(MojoMetadataProvider.Context.FileSet.EmptyDirectoryHandling.valueOf(emptyDirectoryHandling.name()));
+            return this;
+        }
+
+        @Override
+        public MojoMetadataProviderAdapter.Context.FileSet lineEndingHandling(LineEndingHandling lineEndingHandling) {
+            fileSet.lineEndingHandling(MojoMetadataProvider.Context.FileSet.LineEndingHandling.valueOf(lineEndingHandling.name()));
+            return this;
+        }
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseMojoMetadataContext.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseMojoMetadataContext.java
@@ -62,7 +62,7 @@ class GradleEnterpriseMojoMetadataContext implements MojoMetadataProviderAdapter
     @Override
     public MojoMetadataProviderAdapter.Context localState(Consumer<? super MojoMetadataProviderAdapter.Context.LocalState> action) {
         ctx.localState(state -> action.accept(new LocalState(state)));
-        return null;
+        return this;
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseNormalizationContext.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseNormalizationContext.java
@@ -33,7 +33,8 @@ class GradleEnterpriseNormalizationContext implements NormalizationProviderAdapt
 
     @Override
     public NormalizationProviderAdapter.Context configureSystemPropertiesNormalization(Consumer<NormalizationProviderAdapter.SystemPropertiesNormalization> action) {
-        return null;
+        ctx.configureSystemPropertiesNormalization(normalization -> action.accept(new SystemPropertiesNormalization(normalization)));
+        return this;
     }
 
     private static class RuntimeClasspathNormalization implements NormalizationProviderAdapter.RuntimeClasspathNormalization {
@@ -111,6 +112,26 @@ class GradleEnterpriseNormalizationContext implements NormalizationProviderAdapt
                 metaInf.setIgnoreCompletely(ignoreCompletely);
                 return this;
             }
+        }
+    }
+
+    private static class SystemPropertiesNormalization implements NormalizationProviderAdapter.SystemPropertiesNormalization {
+        private final NormalizationProvider.SystemPropertiesNormalization normalization;
+
+        public SystemPropertiesNormalization(NormalizationProvider.SystemPropertiesNormalization normalization) {
+            this.normalization = normalization;
+        }
+
+        @Override
+        public NormalizationProviderAdapter.SystemPropertiesNormalization setIgnoredKeys(List<String> systemPropertyNames) {
+            normalization.setIgnoredKeys(systemPropertyNames);
+            return this;
+        }
+
+        @Override
+        public NormalizationProviderAdapter.SystemPropertiesNormalization addIgnoredKeys(List<String> systemPropertyNames) {
+            normalization.addIgnoredKeys(systemPropertyNames);
+            return this;
         }
     }
 }

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseNormalizationContext.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseNormalizationContext.java
@@ -1,0 +1,116 @@
+package com.gradle.ccud.adapters.enterprise;
+
+import com.gradle.ccud.adapters.NormalizationProviderAdapter;
+import com.gradle.maven.extension.api.cache.NormalizationProvider;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+class GradleEnterpriseNormalizationContext implements NormalizationProviderAdapter.Context {
+    private final NormalizationProvider.Context ctx;
+
+    GradleEnterpriseNormalizationContext(NormalizationProvider.Context ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public MavenProject getProject() {
+        return ctx.getProject();
+    }
+
+    @Override
+    public MavenSession getSession() {
+        return ctx.getSession();
+    }
+
+    @Override
+    public NormalizationProviderAdapter.Context configureRuntimeClasspathNormalization(Consumer<NormalizationProviderAdapter.RuntimeClasspathNormalization> action) {
+        ctx.configureRuntimeClasspathNormalization(normalization -> action.accept(new RuntimeClasspathNormalization(normalization)));
+        return this;
+    }
+
+    @Override
+    public NormalizationProviderAdapter.Context configureSystemPropertiesNormalization(Consumer<NormalizationProviderAdapter.SystemPropertiesNormalization> action) {
+        return null;
+    }
+
+    private static class RuntimeClasspathNormalization implements NormalizationProviderAdapter.RuntimeClasspathNormalization {
+
+        private final NormalizationProvider.RuntimeClasspathNormalization normalization;
+
+        private RuntimeClasspathNormalization(NormalizationProvider.RuntimeClasspathNormalization normalization) {
+            this.normalization = normalization;
+        }
+
+        @Override
+        public NormalizationProviderAdapter.RuntimeClasspathNormalization setIgnoredFiles(List<String> ignoredFiles) {
+            normalization.setIgnoredFiles(ignoredFiles);
+            return this;
+        }
+
+        @Override
+        public NormalizationProviderAdapter.RuntimeClasspathNormalization addIgnoredFiles(List<String> ignoredFiles) {
+            normalization.addIgnoredFiles(ignoredFiles);
+            return this;
+        }
+
+        @Override
+        public NormalizationProviderAdapter.RuntimeClasspathNormalization addPropertiesNormalization(String path, List<String> ignoredProperties) {
+            normalization.addPropertiesNormalization(path, ignoredProperties);
+            return this;
+        }
+
+        @Override
+        public NormalizationProviderAdapter.RuntimeClasspathNormalization configureMetaInf(Consumer<NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf> action) {
+            normalization.configureMetaInf(metaInf -> action.accept(new MetaInf(metaInf)));
+            return this;
+        }
+
+        private static class MetaInf implements NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf {
+
+            private final NormalizationProvider.RuntimeClasspathNormalization.MetaInf metaInf;
+
+            MetaInf(NormalizationProvider.RuntimeClasspathNormalization.MetaInf metaInf) {
+                this.metaInf = metaInf;
+            }
+
+            @Override
+            public NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf setIgnoredAttributes(List<String> ignoredAttributes) {
+                metaInf.setIgnoredAttributes(ignoredAttributes);
+                return this;
+            }
+
+            @Override
+            public NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf addIgnoredAttributes(List<String> ignoredAttributes) {
+                metaInf.addIgnoredAttributes(ignoredAttributes);
+                return this;
+            }
+
+            @Override
+            public NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf setIgnoredProperties(List<String> ignoredProperties) {
+                metaInf.setIgnoredProperties(ignoredProperties);
+                return this;
+            }
+
+            @Override
+            public NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf addIgnoredProperties(List<String> ignoredProperties) {
+                metaInf.addIgnoredProperties(ignoredProperties);
+                return this;
+            }
+
+            @Override
+            public NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf setIgnoreManifest(boolean ignoreManifest) {
+                metaInf.setIgnoreManifest(ignoreManifest);
+                return this;
+            }
+
+            @Override
+            public NormalizationProviderAdapter.RuntimeClasspathNormalization.MetaInf setIgnoreCompletely(boolean ignoreCompletely) {
+                metaInf.setIgnoreCompletely(ignoreCompletely);
+                return this;
+            }
+        }
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/package-info.java
+++ b/src/main/java/com/gradle/ccud/adapters/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package provides an adapter layer supporting uniform interaction pattern with the Develocity and Gradle Enterprise extensions.
+ */
+package com.gradle.ccud.adapters;

--- a/src/main/java/com/gradle/ccud/adapters/shared/DefaultBuildResultAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/shared/DefaultBuildResultAdapter.java
@@ -1,0 +1,19 @@
+package com.gradle.ccud.adapters.shared;
+
+import com.gradle.ccud.adapters.BuildResultAdapter;
+
+import java.util.List;
+
+public class DefaultBuildResultAdapter implements BuildResultAdapter {
+
+    private final List<Throwable> failures;
+
+    public DefaultBuildResultAdapter(List<Throwable> failures) {
+        this.failures = failures;
+    }
+
+    @Override
+    public List<Throwable> getFailures() {
+        return failures;
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/shared/DefaultBuildScanCaptureAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/shared/DefaultBuildScanCaptureAdapter.java
@@ -1,15 +1,15 @@
 package com.gradle.ccud.adapters.shared;
 
 import com.gradle.ccud.adapters.BuildScanCaptureAdapter;
-import com.gradle.ccud.adapters.PropertyConfigurator;
+import com.gradle.ccud.adapters.Property;
 
 public class DefaultBuildScanCaptureAdapter implements BuildScanCaptureAdapter {
 
-    private final PropertyConfigurator<Boolean> goalInputFiles;
-    private final PropertyConfigurator<Boolean> buildLogging;
-    private final PropertyConfigurator<Boolean> testLogging;
+    private final Property<Boolean> goalInputFiles;
+    private final Property<Boolean> buildLogging;
+    private final Property<Boolean> testLogging;
 
-    public DefaultBuildScanCaptureAdapter(PropertyConfigurator<Boolean> goalInputFiles, PropertyConfigurator<Boolean> buildLogging, PropertyConfigurator<Boolean> testLogging) {
+    public DefaultBuildScanCaptureAdapter(Property<Boolean> goalInputFiles, Property<Boolean> buildLogging, Property<Boolean> testLogging) {
         this.goalInputFiles = goalInputFiles;
         this.buildLogging = buildLogging;
         this.testLogging = testLogging;

--- a/src/main/java/com/gradle/ccud/adapters/shared/DefaultBuildScanCaptureAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/shared/DefaultBuildScanCaptureAdapter.java
@@ -1,0 +1,47 @@
+package com.gradle.ccud.adapters.shared;
+
+import com.gradle.ccud.adapters.BuildScanCaptureAdapter;
+import com.gradle.ccud.adapters.PropertyConfigurator;
+
+public class DefaultBuildScanCaptureAdapter implements BuildScanCaptureAdapter {
+
+    private final PropertyConfigurator<Boolean> goalInputFiles;
+    private final PropertyConfigurator<Boolean> buildLogging;
+    private final PropertyConfigurator<Boolean> testLogging;
+
+    public DefaultBuildScanCaptureAdapter(PropertyConfigurator<Boolean> goalInputFiles, PropertyConfigurator<Boolean> buildLogging, PropertyConfigurator<Boolean> testLogging) {
+        this.goalInputFiles = goalInputFiles;
+        this.buildLogging = buildLogging;
+        this.testLogging = testLogging;
+    }
+
+    @Override
+    public void setGoalInputFiles(boolean capture) {
+        goalInputFiles.set(capture);
+    }
+
+    @Override
+    public boolean isGoalInputFiles() {
+        return goalInputFiles.get();
+    }
+
+    @Override
+    public void setBuildLogging(boolean capture) {
+        buildLogging.set(capture);
+    }
+
+    @Override
+    public boolean isBuildLogging() {
+        return buildLogging.get();
+    }
+
+    @Override
+    public void setTestLogging(boolean capture) {
+        testLogging.set(capture);
+    }
+
+    @Override
+    public boolean isTestLogging() {
+        return testLogging.get();
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/shared/DefaultBuildScanDataObfuscationAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/shared/DefaultBuildScanDataObfuscationAdapter.java
@@ -1,0 +1,39 @@
+package com.gradle.ccud.adapters.shared;
+
+import com.gradle.ccud.adapters.BuildScanDataObfuscationAdapter;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.function.Function;
+
+public class DefaultBuildScanDataObfuscationAdapter implements BuildScanDataObfuscationAdapter {
+
+    private final ObfuscatorConsumer<String, String> usernameObfuscator;
+    private final ObfuscatorConsumer<String, String> hostnameObfuscator;
+    private final ObfuscatorConsumer<List<InetAddress>, List<String>> ipAddressesObfuscator;
+
+    public DefaultBuildScanDataObfuscationAdapter(
+        ObfuscatorConsumer<String, String> usernameObfuscator,
+        ObfuscatorConsumer<String, String> hostnameObfuscator,
+        ObfuscatorConsumer<List<InetAddress>, List<String>> ipAddressesObfuscator
+    ) {
+        this.usernameObfuscator = usernameObfuscator;
+        this.hostnameObfuscator = hostnameObfuscator;
+        this.ipAddressesObfuscator = ipAddressesObfuscator;
+    }
+
+    @Override
+    public void username(Function<? super String, ? extends String> obfuscator) {
+        usernameObfuscator.accept(obfuscator);
+    }
+
+    @Override
+    public void hostname(Function<? super String, ? extends String> obfuscator) {
+        hostnameObfuscator.accept(obfuscator);
+    }
+
+    @Override
+    public void ipAddresses(Function<? super List<InetAddress>, ? extends List<String>> obfuscator) {
+        ipAddressesObfuscator.accept(obfuscator);
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/shared/DefaultCleanupPolicyAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/shared/DefaultCleanupPolicyAdapter.java
@@ -1,20 +1,20 @@
 package com.gradle.ccud.adapters.shared;
 
 import com.gradle.ccud.adapters.CleanupPolicyAdapter;
-import com.gradle.ccud.adapters.PropertyConfigurator;
+import com.gradle.ccud.adapters.Property;
 
 import java.time.Duration;
 
 public class DefaultCleanupPolicyAdapter implements CleanupPolicyAdapter {
 
-    private final PropertyConfigurator<Boolean> enabled;
-    private final PropertyConfigurator<Duration> retentionPeriod;
-    private final PropertyConfigurator<Duration> cleanupInterval;
+    private final Property<Boolean> enabled;
+    private final Property<Duration> retentionPeriod;
+    private final Property<Duration> cleanupInterval;
 
     public DefaultCleanupPolicyAdapter(
-        PropertyConfigurator<Boolean> enabled,
-        PropertyConfigurator<Duration> retentionPeriod,
-        PropertyConfigurator<Duration> cleanupInterval
+        Property<Boolean> enabled,
+        Property<Duration> retentionPeriod,
+        Property<Duration> cleanupInterval
     ) {
         this.enabled = enabled;
         this.retentionPeriod = retentionPeriod;

--- a/src/main/java/com/gradle/ccud/adapters/shared/DefaultCleanupPolicyAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/shared/DefaultCleanupPolicyAdapter.java
@@ -1,0 +1,53 @@
+package com.gradle.ccud.adapters.shared;
+
+import com.gradle.ccud.adapters.CleanupPolicyAdapter;
+import com.gradle.ccud.adapters.PropertyConfigurator;
+
+import java.time.Duration;
+
+public class DefaultCleanupPolicyAdapter implements CleanupPolicyAdapter {
+
+    private final PropertyConfigurator<Boolean> enabled;
+    private final PropertyConfigurator<Duration> retentionPeriod;
+    private final PropertyConfigurator<Duration> cleanupInterval;
+
+    public DefaultCleanupPolicyAdapter(
+        PropertyConfigurator<Boolean> enabled,
+        PropertyConfigurator<Duration> retentionPeriod,
+        PropertyConfigurator<Duration> cleanupInterval
+    ) {
+        this.enabled = enabled;
+        this.retentionPeriod = retentionPeriod;
+        this.cleanupInterval = cleanupInterval;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled.get();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        this.enabled.set(enabled);
+    }
+
+    @Override
+    public Duration getRetentionPeriod() {
+        return retentionPeriod.get();
+    }
+
+    @Override
+    public void setRetentionPeriod(Duration retentionPeriod) {
+        this.retentionPeriod.set(retentionPeriod);
+    }
+
+    @Override
+    public Duration getCleanupInterval() {
+        return cleanupInterval.get();
+    }
+
+    @Override
+    public void setCleanupInterval(Duration cleanupInterval) {
+        this.cleanupInterval.set(cleanupInterval);
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/shared/DefaultCredentialsAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/shared/DefaultCredentialsAdapter.java
@@ -1,0 +1,35 @@
+package com.gradle.ccud.adapters.shared;
+
+import com.gradle.ccud.adapters.CredentialsAdapter;
+import com.gradle.ccud.adapters.Property;
+
+public class DefaultCredentialsAdapter implements CredentialsAdapter {
+
+    private final Property<String> username;
+    private final Property<String> password;
+
+    public DefaultCredentialsAdapter(Property<String> username, Property<String> password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username.get();
+    }
+
+    @Override
+    public void setUsername(String username) {
+        this.username.set(username);
+    }
+
+    @Override
+    public String getPassword() {
+        return password.get();
+    }
+
+    @Override
+    public void setPassword(String password) {
+        this.password.set(password);
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/shared/DefaultLocalBuildCacheAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/shared/DefaultLocalBuildCacheAdapter.java
@@ -2,21 +2,21 @@ package com.gradle.ccud.adapters.shared;
 
 import com.gradle.ccud.adapters.CleanupPolicyAdapter;
 import com.gradle.ccud.adapters.LocalBuildCacheAdapter;
-import com.gradle.ccud.adapters.PropertyConfigurator;
+import com.gradle.ccud.adapters.Property;
 
 import java.io.File;
 
 public class DefaultLocalBuildCacheAdapter implements LocalBuildCacheAdapter {
 
-    private final PropertyConfigurator<Boolean> enabled;
-    private final PropertyConfigurator<Boolean> storeEnabled;
-    private final PropertyConfigurator<File> directory;
+    private final Property<Boolean> enabled;
+    private final Property<Boolean> storeEnabled;
+    private final Property<File> directory;
     private final CleanupPolicyAdapter cleanupPolicyAdapter;
 
     public DefaultLocalBuildCacheAdapter(
-        PropertyConfigurator<Boolean> enabled,
-        PropertyConfigurator<Boolean> storeEnabled,
-        PropertyConfigurator<File> directory,
+        Property<Boolean> enabled,
+        Property<Boolean> storeEnabled,
+        Property<File> directory,
         CleanupPolicyAdapter cleanupPolicyAdapter
     ) {
         this.enabled = enabled;

--- a/src/main/java/com/gradle/ccud/adapters/shared/DefaultLocalBuildCacheAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/shared/DefaultLocalBuildCacheAdapter.java
@@ -1,0 +1,62 @@
+package com.gradle.ccud.adapters.shared;
+
+import com.gradle.ccud.adapters.CleanupPolicyAdapter;
+import com.gradle.ccud.adapters.LocalBuildCacheAdapter;
+import com.gradle.ccud.adapters.PropertyConfigurator;
+
+import java.io.File;
+
+public class DefaultLocalBuildCacheAdapter implements LocalBuildCacheAdapter {
+
+    private final PropertyConfigurator<Boolean> enabled;
+    private final PropertyConfigurator<Boolean> storeEnabled;
+    private final PropertyConfigurator<File> directory;
+    private final CleanupPolicyAdapter cleanupPolicyAdapter;
+
+    public DefaultLocalBuildCacheAdapter(
+        PropertyConfigurator<Boolean> enabled,
+        PropertyConfigurator<Boolean> storeEnabled,
+        PropertyConfigurator<File> directory,
+        CleanupPolicyAdapter cleanupPolicyAdapter
+    ) {
+        this.enabled = enabled;
+        this.storeEnabled = storeEnabled;
+        this.directory = directory;
+        this.cleanupPolicyAdapter = cleanupPolicyAdapter;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled.get();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        this.enabled.set(enabled);
+    }
+
+    @Override
+    public boolean isStoreEnabled() {
+        return storeEnabled.get();
+    }
+
+    @Override
+    public void setStoreEnabled(boolean storeEnabled) {
+        this.storeEnabled.set(storeEnabled);
+    }
+
+    @Override
+    public File getDirectory() {
+        return directory.get();
+    }
+
+    @Override
+    public void setDirectory(File directory) {
+        this.directory.set(directory);
+    }
+
+    @Override
+    public CleanupPolicyAdapter getCleanupPolicy() {
+        return cleanupPolicyAdapter;
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/shared/DefaultPublishedBuildScanAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/shared/DefaultPublishedBuildScanAdapter.java
@@ -1,0 +1,26 @@
+package com.gradle.ccud.adapters.shared;
+
+import com.gradle.ccud.adapters.PublishedBuildScanAdapter;
+
+import java.net.URI;
+
+public class DefaultPublishedBuildScanAdapter implements PublishedBuildScanAdapter {
+
+    private final String buildScanId;
+    private final URI buildScanUri;
+
+    public DefaultPublishedBuildScanAdapter(String buildScanId, URI buildScanUri) {
+        this.buildScanId = buildScanId;
+        this.buildScanUri = buildScanUri;
+    }
+
+    @Override
+    public String getBuildScanId() {
+        return buildScanId;
+    }
+
+    @Override
+    public URI getBuildScanUri() {
+        return buildScanUri;
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/shared/DefaultRemoteBuildCacheAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/shared/DefaultRemoteBuildCacheAdapter.java
@@ -1,0 +1,47 @@
+package com.gradle.ccud.adapters.shared;
+
+import com.gradle.ccud.adapters.Property;
+import com.gradle.ccud.adapters.RemoteBuildCacheAdapter;
+import com.gradle.ccud.adapters.ServerAdapter;
+
+public class DefaultRemoteBuildCacheAdapter implements RemoteBuildCacheAdapter {
+
+    private final Property<Boolean> enabled;
+    private final Property<Boolean> storeEnabled;
+    private final ServerAdapter serverAdapter;
+
+    public DefaultRemoteBuildCacheAdapter(
+        Property<Boolean> enabled,
+        Property<Boolean> storeEnabled,
+        ServerAdapter serverAdapter
+    ) {
+        this.enabled = enabled;
+        this.storeEnabled = storeEnabled;
+        this.serverAdapter = serverAdapter;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled.get();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        this.enabled.set(enabled);
+    }
+
+    @Override
+    public boolean isStoreEnabled() {
+        return storeEnabled.get();
+    }
+
+    @Override
+    public void setStoreEnabled(boolean storeEnabled) {
+        this.storeEnabled.set(storeEnabled);
+    }
+
+    @Override
+    public ServerAdapter getServer() {
+        return serverAdapter;
+    }
+}

--- a/src/main/java/com/gradle/ccud/adapters/shared/DefaultServerAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/shared/DefaultServerAdapter.java
@@ -1,0 +1,88 @@
+package com.gradle.ccud.adapters.shared;
+
+import com.gradle.ccud.adapters.CredentialsAdapter;
+import com.gradle.ccud.adapters.Property;
+import com.gradle.ccud.adapters.ServerAdapter;
+
+import java.net.URI;
+
+public class DefaultServerAdapter implements ServerAdapter {
+
+    private final Property<String> serverId;
+    private final Property<URI> url;
+    private final Property<Boolean> allowUntrusted;
+    private final Property<Boolean> allowInsecureProtocol;
+    private final Property<Boolean> useExpectContinue;
+    private final CredentialsAdapter credentialsAdapter;
+
+    public DefaultServerAdapter(
+        Property<String> serverId,
+        Property<URI> url,
+        Property<Boolean> allowUntrusted,
+        Property<Boolean> allowInsecureProtocol,
+        Property<Boolean> useExpectContinue,
+        CredentialsAdapter credentialsAdapter
+    ) {
+        this.serverId = serverId;
+        this.url = url;
+        this.allowUntrusted = allowUntrusted;
+        this.allowInsecureProtocol = allowInsecureProtocol;
+        this.useExpectContinue = useExpectContinue;
+        this.credentialsAdapter = credentialsAdapter;
+    }
+
+    @Override
+    public String getServerId() {
+        return serverId.get();
+    }
+
+    @Override
+    public void setServerId(String serverId) {
+        this.serverId.set(serverId);
+    }
+
+    @Override
+    public URI getUrl() {
+        return url.get();
+    }
+
+    @Override
+    public void setUrl(URI url) {
+        this.url.set(url);
+    }
+
+    @Override
+    public boolean isAllowUntrusted() {
+        return allowUntrusted.get();
+    }
+
+    @Override
+    public void setAllowUntrusted(boolean allowUntrusted) {
+        this.allowUntrusted.set(allowUntrusted);
+    }
+
+    @Override
+    public boolean isAllowInsecureProtocol() {
+        return allowInsecureProtocol.get();
+    }
+
+    @Override
+    public void setAllowInsecureProtocol(boolean allowInsecureProtocol) {
+        this.allowInsecureProtocol.set(allowInsecureProtocol);
+    }
+
+    @Override
+    public boolean isUseExpectContinue() {
+        return useExpectContinue.get();
+    }
+
+    @Override
+    public void setUseExpectContinue(boolean useExpectContinue) {
+        this.useExpectContinue.set(useExpectContinue);
+    }
+
+    @Override
+    public CredentialsAdapter getCredentials() {
+        return credentialsAdapter;
+    }
+}

--- a/src/test/java/com/gradle/ccud/adapters/ReflectionUtilsTest.java
+++ b/src/test/java/com/gradle/ccud/adapters/ReflectionUtilsTest.java
@@ -13,7 +13,6 @@ class ReflectionUtilsTest {
     private static class Subject {
         private int value;
 
-
         public int getValue() {
             return value;
         }

--- a/src/test/java/com/gradle/ccud/adapters/ReflectionUtilsTest.java
+++ b/src/test/java/com/gradle/ccud/adapters/ReflectionUtilsTest.java
@@ -1,0 +1,88 @@
+package com.gradle.ccud.adapters;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.gradle.ccud.adapters.ReflectionUtils.invokeMethod;
+import static com.gradle.ccud.adapters.ReflectionUtils.withMethodSupported;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ReflectionUtilsTest {
+
+    private static class Subject {
+        private int value;
+
+
+        public int getValue() {
+            return value;
+        }
+
+        public void setValue(int value) {
+            this.value = value;
+        }
+    }
+
+    @Test
+    @DisplayName("can invoke supported void methods")
+    void testInvokeVoidMethodsWithArgs() {
+        // given
+        Subject s = new Subject();
+
+        // when
+        invokeMethod(s, "setValue", 11);
+
+        // then
+        assertEquals(11, s.value);
+    }
+
+    @Test
+    @DisplayName("can invoke methods returning values")
+    void testInvokeGettersWithNoArgs() {
+        // given
+        Subject s = new Subject();
+        s.setValue(22);
+
+        // expect
+        assertEquals(22, invokeMethod(s, "getValue"));
+    }
+
+    @Test
+    @DisplayName("does not fail if the requested method is unsupported")
+    void testInvokeMissingMethods() {
+        // given
+        Subject s = new Subject();
+
+        // when
+        assertNull(invokeMethod(s, "unsupported"));
+        assertNull(invokeMethod(s, "unsupported", 42));
+    }
+
+    @Test
+    @DisplayName("can invoke requested action if method used is supported")
+    void testInvokeActionIfMethodSupported() {
+        // given
+        Subject s = new Subject();
+
+        // when
+        withMethodSupported(s, "setValue", () -> s.setValue(33));
+
+        // then
+        assertEquals(33, s.value);
+    }
+
+    @Test
+    @DisplayName("does not perform the action if method requested is unsupported")
+    void testInvokeActionIfMethodUnsupported() {
+        // given
+        Subject s = new Subject();
+        s.setValue(44);
+
+        // when
+        withMethodSupported(s, "unsupported", () -> s.setValue(55));
+
+        // then
+        assertEquals(44, s.value);
+    }
+
+}


### PR DESCRIPTION
## Summary
Update the extension to configure either the GE or the DV extensions. The extension registers both `GradleEnterpriseListener` and `DevelocityListener`. The DV extension knows how to de-duplicate listener invocations ([see](https://github.com/gradle/ge/pull/32967)). Both listeners do the same thing. They use the adapter layer to wrap the `GradleEnterpriseApi` and the `DevelocityApi` to perform the configuration.
