### PR TITLE
Use "Terms of Use" terminology instead of "Terms of Service"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.gradle</groupId>
             <artifactId>develocity-maven-extension</artifactId>
-            <version>1.21-rc-1</version>
+            <version>1.21-rc-2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/gradle/ccud/adapters/BuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/BuildScanApiAdapter.java
@@ -21,13 +21,13 @@ public interface BuildScanApiAdapter {
 
     void buildScanPublished(Consumer<? super PublishedBuildScanAdapter> action);
 
-    void setTermsOfServiceUrl(String termsOfServiceUrl);
+    void setTermsOfUseUrl(String termsOfServiceUrl);
 
-    String getTermsOfServiceUrl();
+    String getTermsOfUseUrl();
 
-    void setTermsOfServiceAgree(String agree);
+    void setTermsOfUseAgree(String agree);
 
-    String getTermsOfServiceAgree();
+    String getTermsOfUseAgree();
 
     default void setServer(String url) {
         setServer(url == null ? null : URI.create(url));

--- a/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/develocity/DevelocityBuildScanApiAdapter.java
@@ -66,23 +66,23 @@ class DevelocityBuildScanApiAdapter implements BuildScanApiAdapter {
     }
 
     @Override
-    public void setTermsOfServiceUrl(String termsOfServiceUrl) {
-        buildScan.setTermsOfServiceUrl(termsOfServiceUrl);
+    public void setTermsOfUseUrl(String termsOfServiceUrl) {
+        buildScan.setTermsOfUseUrl(termsOfServiceUrl);
     }
 
     @Override
-    public String getTermsOfServiceUrl() {
-        return buildScan.getTermsOfServiceUrl();
+    public String getTermsOfUseUrl() {
+        return buildScan.getTermsOfUseUrl();
     }
 
     @Override
-    public void setTermsOfServiceAgree(String agree) {
-        buildScan.setTermsOfServiceAgree(agree);
+    public void setTermsOfUseAgree(String agree) {
+        buildScan.setTermsOfUseAgree(agree);
     }
 
     @Override
-    public String getTermsOfServiceAgree() {
-        return buildScan.getTermsOfServiceAgree();
+    public String getTermsOfUseAgree() {
+        return buildScan.getTermsOfUseAgree();
     }
 
     @Override

--- a/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
+++ b/src/main/java/com/gradle/ccud/adapters/enterprise/GradleEnterpriseBuildScanApiAdapter.java
@@ -66,22 +66,22 @@ class GradleEnterpriseBuildScanApiAdapter implements BuildScanApiAdapter {
     }
 
     @Override
-    public void setTermsOfServiceUrl(String termsOfServiceUrl) {
+    public void setTermsOfUseUrl(String termsOfServiceUrl) {
         buildScan.setTermsOfServiceUrl(termsOfServiceUrl);
     }
 
     @Override
-    public String getTermsOfServiceUrl() {
+    public String getTermsOfUseUrl() {
         return buildScan.getTermsOfServiceUrl();
     }
 
     @Override
-    public void setTermsOfServiceAgree(String agree) {
+    public void setTermsOfUseAgree(String agree) {
         buildScan.setTermsOfServiceAgree(agree);
     }
 
     @Override
-    public String getTermsOfServiceAgree() {
+    public String getTermsOfUseAgree() {
         return buildScan.getTermsOfServiceAgree();
     }
 


### PR DESCRIPTION
In RC2, the termsOfService APIs have been renamed to termsOfUse. This commit uses the new terminology in the adapter APIs + fixes compilation errors caused by the breaking changes in the RC