### PR TITLE
Fixed empty PR branch custom value

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -248,7 +248,7 @@ final class CustomBuildScanEnhancements {
                     addCustomValueAndSearchLink(buildScan, "CI workflow", value));
                 envVariable("GITHUB_RUN_ID").ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI run", value));
-                envVariable("GITHUB_HEAD_REF").ifPresent(value ->
+                envVariable("GITHUB_HEAD_REF").filter(value -> !value.isEmpty()).ifPresent(value ->
                         buildScan.value("PR branch", value));
             }
 


### PR DESCRIPTION
Fixes issue https://github.com/gradle/common-custom-user-data-maven-extension/issues/215.

Scans after the fix:
- with `export GITHUB_HEAD_REF=someBranch`: [scan](https://ge.solutions-team.gradle.com/s/gsp3eykuctwjk/custom-values#L7)
- with `export GITHUB_HEAD_REF= `: [scan](https://ge.solutions-team.gradle.com/s/eewzqm5nvryzy/custom-values)