### PR TITLE
NOTICE and LICENSE files are included in assembled JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,12 +149,34 @@
                 <configuration>
                     <filters>
                         <filter>
-                            <artifact>org.codehaus.groovy:groovy</artifact>
+                            <artifact>com.gradle:develocity-maven-extension-adapters</artifact>
                             <excludes>
                                 <exclude>META-INF/MANIFEST.MF</exclude>
                             </excludes>
                         </filter>
+                        <filter>
+                            <artifact>org.codehaus.groovy:groovy</artifact>
+                            <excludes>
+                                <exclude>META-INF/LICENSE</exclude>
+                                <exclude>META-INF/MANIFEST.MF</exclude>
+                                <exclude>META-INF/NOTICE</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>org.apache.ivy:ivy</artifact>
+                            <excludes>
+                                <exclude>META-INF/LICENSE</exclude>
+                                <exclude>META-INF/MANIFEST.MF</exclude>
+                                <exclude>META-INF/NOTICE</exclude>
+                            </excludes>
+                        </filter>
                     </filters>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                            <resource>LICENSE</resource>
+                            <file>${project.basedir}/LICENSE</file>
+                        </transformer>
+                    </transformers>
                 </configuration>
                 <executions>
                     <execution>
@@ -166,6 +188,11 @@
                 </executions>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/release/distribution</directory>
+            </resource>
+        </resources>
     </build>
 
     <profiles>

--- a/release/distribution/NOTICE
+++ b/release/distribution/NOTICE
@@ -1,0 +1,74 @@
+The following copyright statements and licenses apply to various third party open
+source software packages (or portions thereof) that are distributed with
+this content.
+
+TABLE OF CONTENTS
+=================
+
+The following is a listing of the open source components detailed in this
+document.  This list is provided for your convenience; please read further if
+you wish to review the copyright notice(s) and the full text of the license
+associated with each component.
+
+
+**SECTION 1: Apache License, V2.0**
+  * Develocity Maven Extension Adapters
+    * com.gradle:develocity-maven-extension-adapters
+  * Groovy
+    * org.codehaus.groovy:groovy
+  * Ivy
+    * org.apache.ivy:ivy
+
+SECTION 1: Apache License, V2.0
+================================
+
+Develocity Maven Extension Adapters
+-----------------------------------
+
+Copyright 2024 Gradle, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Groovy
+------
+
+Copyright 2023 The Apache Software Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Ivy
+---
+
+Copyright 2023 The Apache Software Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
This PR adds a NOTICE file to the root of the project. The NOTICE file includes the licenses of all runtime dependencies, as can be seen in [this build scan](https://ge.solutions-team.gradle.com/s/occfwoiar7gn4/dependencies?toggled=WyIwLjAiLCIwLjAtMS4xIl0#MC4wLTEuMQ).

Both the NOTICE and LICENSE files are then included in the assembled JAR.