### PR TITLE
Deprecated Plexus @Component annotations are replaced by JSR-330 annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,12 +64,6 @@
             <version>3.9.6</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-component-annotations</artifactId>
-            <version>2.2.0</version>
-            <scope>provided</scope>
-        </dependency>
         <!-- exposes GradleEnterprise* interfaces -->
         <dependency>
             <groupId>com.gradle</groupId>
@@ -129,18 +123,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-component-metadata</artifactId>
-                <version>2.2.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate-metadata</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/gradle/CommonCustomUserDataDevelocityListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataDevelocityListener.java
@@ -5,14 +5,14 @@ import com.gradle.develocity.agent.maven.api.DevelocityApi;
 import com.gradle.develocity.agent.maven.api.DevelocityListener;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
-import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.sisu.Description;
 
-@SuppressWarnings("unused")
-@Component(
-    role = DevelocityListener.class,
-    hint = "common-custom-user-data-develocity-listener",
-    description = "Captures common custom user data in Maven build scans"
-)
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+@Named("common-custom-user-data-develocity-listener")
+@Singleton
+@Description("Captures common custom user data in Maven Build Scan")
 public final class CommonCustomUserDataDevelocityListener extends CommonCustomUserDataListener implements DevelocityListener {
 
     @Override

--- a/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
@@ -5,14 +5,14 @@ import com.gradle.maven.extension.api.GradleEnterpriseApi;
 import com.gradle.maven.extension.api.GradleEnterpriseListener;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
-import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.sisu.Description;
 
-@SuppressWarnings("unused")
-@Component(
-    role = GradleEnterpriseListener.class,
-    hint = "common-custom-user-data-gradle-enterprise-listener",
-    description = "Captures common custom user data in Maven build scans"
-)
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+@Named("common-custom-user-data-gradle-enterprise-listener")
+@Singleton
+@Description("Captures common custom user data in Maven Build Scan")
 public final class CommonCustomUserDataGradleEnterpriseListener extends CommonCustomUserDataListener implements GradleEnterpriseListener {
 
     @Override

--- a/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,0 +1,2 @@
+com.gradle.CommonCustomUserDataDevelocityListener
+com.gradle.CommonCustomUserDataGradleEnterpriseListener


### PR DESCRIPTION
This PR removes the deprecated `@Component` annotations from the `DevelocityListener` and `GradleEnterpriseListener` classes. They have been replaced with a dedicated file at `src/main/resources/META-INF/plexus/components.xml` instead.

I verified this didn't have any impact when the extension is applied to the following Maven versions:

- 3.6.3: https://ge.solutions-team.gradle.com/s/55246cakeps4c
- 3.8.7: https://ge.solutions-team.gradle.com/s/7pcdtxe62ubvy
- 3.9.9: https://ge.solutions-team.gradle.com/s/syw4fushq7ns2