### PR TITLE
Deprecated Plexus @Component annotations are removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,12 +64,6 @@
             <version>3.9.6</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-component-annotations</artifactId>
-            <version>2.2.0</version>
-            <scope>provided</scope>
-        </dependency>
         <!-- exposes GradleEnterprise* interfaces -->
         <dependency>
             <groupId>com.gradle</groupId>
@@ -129,18 +123,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-component-metadata</artifactId>
-                <version>2.2.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate-metadata</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/gradle/CommonCustomUserDataDevelocityListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataDevelocityListener.java
@@ -5,14 +5,7 @@ import com.gradle.develocity.agent.maven.api.DevelocityApi;
 import com.gradle.develocity.agent.maven.api.DevelocityListener;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
-import org.codehaus.plexus.component.annotations.Component;
 
-@SuppressWarnings("unused")
-@Component(
-    role = DevelocityListener.class,
-    hint = "common-custom-user-data-develocity-listener",
-    description = "Captures common custom user data in Maven build scans"
-)
 public final class CommonCustomUserDataDevelocityListener extends CommonCustomUserDataListener implements DevelocityListener {
 
     @Override

--- a/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
+++ b/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
@@ -5,14 +5,7 @@ import com.gradle.maven.extension.api.GradleEnterpriseApi;
 import com.gradle.maven.extension.api.GradleEnterpriseListener;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
-import org.codehaus.plexus.component.annotations.Component;
 
-@SuppressWarnings("unused")
-@Component(
-    role = GradleEnterpriseListener.class,
-    hint = "common-custom-user-data-gradle-enterprise-listener",
-    description = "Captures common custom user data in Maven build scans"
-)
 public final class CommonCustomUserDataGradleEnterpriseListener extends CommonCustomUserDataListener implements GradleEnterpriseListener {
 
     @Override

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,18 @@
+<component-set>
+    <components>
+        <component>
+            <role>com.gradle.develocity.agent.maven.api.DevelocityListener</role>
+            <role-hint>common-custom-user-data-develocity-listener</role-hint>
+            <implementation>com.gradle.CommonCustomUserDataDevelocityListener</implementation>
+            <description>Captures common custom user data in Maven Build Scan</description>
+            <isolated-realm>false</isolated-realm>
+        </component>
+        <component>
+            <role>com.gradle.maven.extension.api.GradleEnterpriseListener</role>
+            <role-hint>common-custom-user-data-gradle-enterprise-listener</role-hint>
+            <implementation>com.gradle.CommonCustomUserDataGradleEnterpriseListener</implementation>
+            <description>Captures common custom user data in Maven Build Scan</description>
+            <isolated-realm>false</isolated-realm>
+        </component>
+    </components>
+</component-set>


### PR DESCRIPTION
The changes merged with #242 to replace the `@Component` annotations with JSR-330 annotations, didn't work and needed to be reverted. This was also missed during testing. A deeper follow up investigation is planned to be done by the Maven team.

We decided in the meantime the path of least resistance would be to revert back to the original plan to just remove the deprecated `@Component` annotations.

I have verified these changes against the following Maven versions:

- 3.3.1: https://ge.solutions-team.gradle.com/s/5v5dkvrkggnrg/extensions?expanded=WyIxIl0#2
- 3.6.3: https://ge.solutions-team.gradle.com/s/qnwt3m5qbypi4/extensions?expanded=WyIxIl0#2
- 3.8.7: https://ge.solutions-team.gradle.com/s/at5q5jj2yxio6/extensions?expanded=WyIxIl0#2
- 3.9.9: https://ge.solutions-team.gradle.com/s/cj6pzg2u5fyck/extensions?expanded=WyIxIl0#2

I have also verified these changes by running the CCUD Maven functional tests from the Develocity repository:

- https://develocity.grdev.net/s/e674fdpc3sk4a/tests/overview
 