### PR TITLE
Maven Central is used to resolve dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,6 @@
         </developer>
     </developers>
 
-    <repositories>
-        <repository>
-            <id>Develocity extension RC repository</id>
-            <url>https://repo.grdev.net/artifactory/public</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
This PR removes `repo.grdev.net` as a configured repository, which only contains RCs of the Develocity Maven extension and doesn't even contain any versions of CCUD Maven extension. This was causing Dependabot to no longer upgrade these in `pom.xml` and `.mvn/extensions.xml`.

See the commit history for `.mvn/extensions.xml` where all of a sudden Dependabot stopped updating those versions and for some reason we decided to just start manually updating it. 🙃 

https://github.com/gradle/common-custom-user-data-maven-extension/commits/main/.mvn/extensions.xml