### PR TITLE
Use generic env var to detect CI

### DIFF
--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -8,7 +8,7 @@
     <allowUntrusted>false</allowUntrusted>
   </server>
   <buildScan>
-    <backgroundBuildScanUpload>#{isFalse(env['GITHUB_ACTIONS'])}</backgroundBuildScanUpload>
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
     <publishing>
       <onlyIf>
         <![CDATA[authenticated]]>
@@ -23,7 +23,7 @@
       <enabled>true</enabled>
     </local>
     <remote>
-      <storeEnabled>#{isTrue(env['GITHUB_ACTIONS']) and isTrue(env['DEVELOCITY_ACCESS_KEY'])}</storeEnabled>
+      <storeEnabled>#{isTrue(env['CI']) and isTrue(env['DEVELOCITY_ACCESS_KEY'])}</storeEnabled>
     </remote>
   </buildCache>
 </develocity>


### PR DESCRIPTION
The CCUDME build runs on both GitHub Actions and TeamCity. This change will correctly configure Develocity in both environments.

See [this thread](https://gradle.slack.com/archives/C011SB27MA6/p1723818756713959) for more details.