### PR TITLE
Update to Groovy 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
             <version>1.0</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>3.0.24</version>
+            <version>4.0.26</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ivy</groupId>

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,1 @@
+- [FIX] Update to Groovy 4 to handle Java 24


### PR DESCRIPTION
This PR updates the version of Groovy used to execute the `develocity-customer-user-data.groovy` file. Without this, certain Groovy code may fail to execute when running on Java 24.