### PR TITLE
Added VS Code detection support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 *.DS_Store
 /dependency-reduced-pom.xml
 /.mvn/.develocity/develocity-workspace-id
+.vscode/

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,1 @@
+- [NEW] Added tagging VS Code builds

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -51,6 +51,8 @@ final class CustomBuildScanEnhancements {
     private static final String SYSTEM_PROP_IDEA_VERSION = "idea.version";
     private static final String SYSTEM_PROP_ECLIPSE_BUILD_ID = "eclipse.buildId";
     private static final String SYSTEM_PROP_IDEA_SYNC_ACTIVE = "idea.sync.active";
+    private static final String ENV_VAR_VSCODE_PID = "VSCODE_PID";
+    private static final String ENV_VAR_VSCODE_INJECTION = "VSCODE_INJECTION";
 
     private final BuildScanApiAdapter buildScan;
     private final MavenSession mavenSession;
@@ -80,6 +82,8 @@ final class CustomBuildScanEnhancements {
             ideProperties.put(SYSTEM_PROP_IDEA_VERSION, sysProperty(SYSTEM_PROP_IDEA_VERSION));
             ideProperties.put(SYSTEM_PROP_ECLIPSE_BUILD_ID, sysProperty(SYSTEM_PROP_ECLIPSE_BUILD_ID));
             ideProperties.put(SYSTEM_PROP_IDEA_SYNC_ACTIVE, sysProperty(SYSTEM_PROP_IDEA_SYNC_ACTIVE));
+            ideProperties.put(ENV_VAR_VSCODE_PID, envVariable(ENV_VAR_VSCODE_PID));
+            ideProperties.put(ENV_VAR_VSCODE_INJECTION, envVariable(ENV_VAR_VSCODE_INJECTION));
 
             new CaptureIdeMetadataAction(buildScan, ideProperties).execute();
         }
@@ -106,6 +110,10 @@ final class CustomBuildScanEnhancements {
                 tagIde("IntelliJ IDEA", props.get(SYSTEM_PROP_IDEA_VERSION).get());
             } else if (props.get(SYSTEM_PROP_ECLIPSE_BUILD_ID).isPresent()) {
                 tagIde("Eclipse", props.get(SYSTEM_PROP_ECLIPSE_BUILD_ID).get());
+            } else if (props.get(ENV_VAR_VSCODE_PID).isPresent()) {
+                tagIde("VS Code", "");
+            } else if (props.get(ENV_VAR_VSCODE_INJECTION).isPresent()) {
+                tagIde("VS Code", "");
             } else {
                 buildScan.tag("Cmd Line");
             }

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -110,9 +110,7 @@ final class CustomBuildScanEnhancements {
                 tagIde("IntelliJ IDEA", props.get(SYSTEM_PROP_IDEA_VERSION).get());
             } else if (props.get(SYSTEM_PROP_ECLIPSE_BUILD_ID).isPresent()) {
                 tagIde("Eclipse", props.get(SYSTEM_PROP_ECLIPSE_BUILD_ID).get());
-            } else if (props.get(ENV_VAR_VSCODE_PID).isPresent()) {
-                tagIde("VS Code", "");
-            } else if (props.get(ENV_VAR_VSCODE_INJECTION).isPresent()) {
+            } else if (props.get(ENV_VAR_VSCODE_PID).isPresent() || props.get(ENV_VAR_VSCODE_INJECTION).isPresent()) {
                 tagIde("VS Code", "");
             } else {
                 buildScan.tag("Cmd Line");


### PR DESCRIPTION
Added VS Code detection support.

The VS Code [Maven for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-maven) extension is exposing the `VSCODE_INJECTION` env var, which is used for VS Code builds detection, together with `VSCODE_PID` env var, which we've seen elsewhere. Combining these two env vars, should give us good enough coverage to cover all cases of people using VS Code.

[Here](https://ge.solutions-team.gradle.com/s/lzlsnxrrgtptq) is an example scan produced with VS Code, where the `VS Code` tag is visible.