### PR TITLE
Publish to Maven Central with central-publishing-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
                             <publishingServerId>ossrh</publishingServerId>
                             <autoPublish>true</autoPublish>
                             <waitUntil>published</waitUntil>
-                            <deploymentName>Common custom user data maven extension</deploymentName>
+                            <deploymentName>Common Custom User Data Maven Extension</deploymentName>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -32,14 +32,6 @@
             <id>Documentation</id>
             <url>https://docs.gradle.com</url>
         </site>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
     </distributionManagement>
 
     <developers>
@@ -238,6 +230,18 @@
                         </executions>
                         <configuration>
                             <skipNoKey>false</skipNoKey>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>ossrh</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                            <deploymentName>Common custom user data maven extension</deploymentName>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
### Issue
The [sunset of ossrh protocol](https://central.sonatype.org/publish/publish-guide/) to publish artifacts to Maven Central requires a change in the publication process

### Fix
Use the `central-publishing-maven-plugin` plugin as hinted [there](https://central.sonatype.org/publish/publish-portal-guide/)