### PR TITLE
Added a local selftest to the build-verification.yaml

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -14,7 +14,62 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
-      - name: Build with Maven
-        run: ./mvnw clean verify -B
+      - name: Build and publish to Maven Local with Maven
+        run: ./mvnw clean install -B
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
+      - name: Upload published plugin
+        uses: actions/upload-artifact@v4
+        with:
+          name: common-custom-user-data-maven-plugin
+          path: ~/.m2/repository/com/gradle
+
+  local-test:
+    name: Test with Locally Published Plugin
+    runs-on: ubuntu-latest
+    needs: verification
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Download plugin to maven local
+        uses: actions/download-artifact@v4
+        with:
+          name: common-custom-user-data-maven-plugin
+          path: ~/.m2/repository/com/gradle
+      - name: Create a test project
+        run: |
+          mkdir -p ${{ runner.temp }}/.mvn
+          cp .mvn/develocity.xml ${{ runner.temp }}/.mvn/develocity.xml
+          echo """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+            <extensions>
+              <extension>
+                <groupId>com.gradle</groupId>
+                <artifactId>develocity-maven-extension</artifactId>
+                <version>[2.0,)</version>
+              </extension>
+              <extension>
+                <groupId>com.gradle</groupId>
+                <artifactId>common-custom-user-data-maven-extension</artifactId>
+                <version>[2.0,)</version>
+              </extension>
+            </extensions>
+          """ > ${{ runner.temp }}/.mvn/extensions.xml
+          echo """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+            <project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.example</groupId>
+              <artifactId>ccud-maven-integration-test</artifactId>
+              <version>1.0.0-SNAPSHOT</version>
+            </project>
+          """ > ${{ runner.temp }}/pom.xml
+      - name: Run a build with the locally published plugin
+        id: build-with-local-plugin
+        run: mvn validate
+        working-directory: ${{ runner.temp }}
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}


### PR DESCRIPTION
Added a local selftest to the build-verification.yaml, same logic as we have for CCUD Gradle - see [CCUD Gradle PR](https://github.com/gradle/common-custom-user-data-gradle-plugin/pull/410).

See the [build](https://github.com/gradle/common-custom-user-data-maven-extension/actions/runs/16221456375) with these changes.