### PR TITLE
Add a custom value for GITHUB_RUN_NUMBER

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -254,6 +254,8 @@ final class CustomBuildScanEnhancements {
                     addCustomValueAndSearchLink(buildScan, "CI workflow", value));
                 envVariable("GITHUB_RUN_ID").ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI run", value));
+                envVariable("GITHUB_RUN_NUMBER").ifPresent(value ->
+                        addCustomValueAndSearchLink(buildScan, "CI run number", value));
                 envVariable("GITHUB_ACTION").ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI step", value));
                 envVariable("GITHUB_JOB").ifPresent(value ->

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -255,7 +255,7 @@ final class CustomBuildScanEnhancements {
                 envVariable("GITHUB_RUN_ID").ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI run", value));
                 envVariable("GITHUB_RUN_NUMBER").ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI run number", value));
+                        buildScan.value("CI run number", value));
                 envVariable("GITHUB_ACTION").ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI step", value));
                 envVariable("GITHUB_JOB").ifPresent(value ->


### PR DESCRIPTION
The GitHub run number is needed to precisely identify which GitHub Action run
executed the build which produced the build scan. Run ID alone is not
sufficient.
