### PR TITLE
Remove references to enterprise-samples.gradle.com

### DIFF
--- a/src/main/java/com/gradle/CustomDevelocityConfig.java
+++ b/src/main/java/com/gradle/CustomDevelocityConfig.java
@@ -13,7 +13,7 @@ final class CustomDevelocityConfig {
     void configureDevelocity(DevelocityAdapter develocity) {
         /* Example of Develocity configuration
 
-        develocity.setServer("https://enterprise-samples.gradle.com");
+        develocity.setServer("https://develocity.example.com");
         develocity.setAllowUntrustedServer(false);
 
         */


### PR DESCRIPTION
We want to decommission enterprise-samples.gradle.com and therefore we remove all references to it.