### PR TITLE
Add link to GitHub pull request

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -15,6 +15,8 @@ import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static com.gradle.CiUtils.isAzurePipelines;
@@ -254,6 +256,7 @@ final class CustomBuildScanEnhancements {
                 Optional<String> headRef = envVariable("GITHUB_HEAD_REF").filter(value -> !value.isEmpty());
                 Optional<String> serverUrl = envVariable("GITHUB_SERVER_URL");
                 Optional<String> gitRepository = envVariable("GITHUB_REPOSITORY");
+                Optional<String> refName = envVariable("GITHUB_REF_NAME");
 
                 workflow.ifPresent(value ->
                         addCustomValueAndSearchLink(buildScan, "CI workflow", value));
@@ -277,6 +280,17 @@ final class CustomBuildScanEnhancements {
                             .append("/actions/runs/").append(runId.get());
                     runAttempt.ifPresent(value -> githubActionsBuild.append("/attempts/").append(value));
                     buildScan.link("GitHub Actions build", githubActionsBuild.toString());
+                }
+
+                boolean isPullRequestBuild = headRef.isPresent();
+                if (serverUrl.isPresent() && gitRepository.isPresent() && isPullRequestBuild && refName.isPresent()) {
+                    Matcher matcher = Pattern.compile("^(\\d+)/merge$").matcher(refName.get());
+                    if (matcher.matches()) {
+                        String githubPullRequest = serverUrl.get() +
+                                "/" + gitRepository.get() +
+                                "/pull/" + matcher.group(1);
+                        buildScan.link("GitHub pull request", githubPullRequest);
+                    }
                 }
 
                 if (runId.isPresent()) {


### PR DESCRIPTION
## Summary

- When running on GitHub Actions for a pull request build, extract the PR number from `GITHUB_REF_NAME` and add a direct "GitHub pull request" link to the build scan
- Mirrors the equivalent change from the Gradle plugin: https://github.com/gradle/common-custom-user-data-gradle-plugin/pull/472

## Test plan

- [ ] Verify the extension compiles and tests pass
- [ ] Trigger a GitHub Actions PR build and confirm the "GitHub pull request" link appears in the build scan