### PR TITLE
Add tag and custom value when Maven was invoked by AI Agents

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -69,6 +69,7 @@ final class CustomBuildScanEnhancements {
         captureCiMetadata();
         captureGitMetadata();
         captureSkipTestsFlags();
+        captureAgentMetadata();
     }
 
     private void captureOs() {
@@ -498,6 +499,33 @@ final class CustomBuildScanEnhancements {
             if (value.isEmpty() || Boolean.valueOf(value).equals(Boolean.TRUE)) {
                 buildScan.value("switches." + property, "On");
             }
+        });
+    }
+
+    private void captureAgentMetadata() {
+        Optional<String> claudeCode = envVariable("CLAUDECODE");
+        // Codex environment variables are not officially documented.
+        // This is best effort detection until something more official is implemented by Codex.
+        Optional<String> codexSandbox = envVariable("CODEX_SANDBOX_NETWORK_DISABLED");
+        Optional<String> codexThreadId = envVariable("CODEX_THREAD_ID");
+        Optional<String> openCode = envVariable("OPENCODE");
+        Optional<String> gemini = envVariable("GEMINI_CLI");
+
+        claudeCode.ifPresent(v -> {
+            buildScan.tag("AI Agent");
+            buildScan.value("AI Agent", "Claude Code");
+        });
+        if (codexSandbox.isPresent() || codexThreadId.isPresent()) {
+            buildScan.tag("AI Agent");
+            buildScan.value("AI Agent", "Codex");
+        }
+        openCode.ifPresent(v -> {
+            buildScan.tag("AI Agent");
+            buildScan.value("AI Agent", "OpenCode");
+        });
+        gemini.ifPresent(v -> {
+            buildScan.tag("AI Agent");
+            buildScan.value("AI Agent", "Gemini CLI");
         });
     }
 

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -512,20 +512,20 @@ final class CustomBuildScanEnhancements {
         Optional<String> gemini = envVariable("GEMINI_CLI");
 
         claudeCode.ifPresent(v -> {
-            buildScan.tag("AI Agent");
-            buildScan.value("AI Agent", "Claude Code");
+            buildScan.tag("AI");
+            buildScan.value("AI agent", "Claude Code");
         });
         if (codexSandbox.isPresent() || codexThreadId.isPresent()) {
-            buildScan.tag("AI Agent");
-            buildScan.value("AI Agent", "Codex");
+            buildScan.tag("AI");
+            buildScan.value("AI agent", "Codex");
         }
         openCode.ifPresent(v -> {
-            buildScan.tag("AI Agent");
-            buildScan.value("AI Agent", "OpenCode");
+            buildScan.tag("AI");
+            buildScan.value("AI agent", "OpenCode");
         });
         gemini.ifPresent(v -> {
-            buildScan.tag("AI Agent");
-            buildScan.value("AI Agent", "Gemini CLI");
+            buildScan.tag("AI");
+            buildScan.value("AI agent", "Gemini CLI");
         });
     }
 


### PR DESCRIPTION
## Summary
- Detect AI agent environment variables (Claude Code, Codex, OpenCode, Gemini CLI) and add an "AI" tag and "AI agent" custom value to build scans
- Ports the feature from [common-custom-user-data-gradle-plugin#465](https://github.com/gradle/common-custom-user-data-gradle-plugin/pull/465)