### PR TITLE
Capture GITHUB_BASE_REF as 'PR base branch' for GitHub PR builds

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,3 +1,4 @@
 - [NEW] Add AI tag to the Build Scan when invoked by an AI Agent
 - [NEW] Add custom value to the Build Scan indicating which AI Agent invoked the build
 - [NEW] Add link in Build Scan to GitHub PR
+- [NEW] For GitHub PRs, capture `GITHUB_BASE_REF` as the value `PR base branch`

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -255,6 +255,7 @@ final class CustomBuildScanEnhancements {
                 Optional<String> runAttempt = envVariable("GITHUB_RUN_ATTEMPT");
                 Optional<String> runNumber = envVariable("GITHUB_RUN_NUMBER");
                 Optional<String> headRef = envVariable("GITHUB_HEAD_REF").filter(value -> !value.isEmpty());
+                Optional<String> baseRef = envVariable("GITHUB_BASE_REF").filter(value -> !value.isEmpty());
                 Optional<String> serverUrl = envVariable("GITHUB_SERVER_URL");
                 Optional<String> gitRepository = envVariable("GITHUB_REPOSITORY");
                 Optional<String> refName = envVariable("GITHUB_REF_NAME");
@@ -274,6 +275,8 @@ final class CustomBuildScanEnhancements {
                         buildScan.value("CI run number", value));
                 headRef.ifPresent(value ->
                         buildScan.value("PR branch", value));
+                baseRef.ifPresent(value ->
+                        buildScan.value("PR base branch", value));
 
                 if (serverUrl.isPresent() && gitRepository.isPresent() && runId.isPresent()) {
                     StringBuilder githubActionsBuild = new StringBuilder(serverUrl.get())


### PR DESCRIPTION
Port of gradle/common-custom-user-data-gradle-plugin#490.

For GitHub PR builds, reads the `GITHUB_BASE_REF` environment variable and captures it as a `PR base branch` custom value on the build scan.