### PR TITLE
Capture AI agent metadata in a buildFinished action

### DIFF
--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -520,29 +520,31 @@ final class CustomBuildScanEnhancements {
     }
 
     private void captureAgentMetadata() {
-        Optional<String> claudeCode = envVariable("CLAUDECODE");
-        // Codex environment variables are not officially documented.
-        // This is best effort detection until something more official is implemented by Codex.
-        Optional<String> codexSandbox = envVariable("CODEX_SANDBOX_NETWORK_DISABLED");
-        Optional<String> codexThreadId = envVariable("CODEX_THREAD_ID");
-        Optional<String> openCode = envVariable("OPENCODE");
-        Optional<String> gemini = envVariable("GEMINI_CLI");
+        buildScan.buildFinished(result -> {
+            Optional<String> claudeCode = envVariable("CLAUDECODE");
+            // Codex environment variables are not officially documented.
+            // This is best effort detection until something more official is implemented by Codex.
+            Optional<String> codexSandbox = envVariable("CODEX_SANDBOX_NETWORK_DISABLED");
+            Optional<String> codexThreadId = envVariable("CODEX_THREAD_ID");
+            Optional<String> openCode = envVariable("OPENCODE");
+            Optional<String> gemini = envVariable("GEMINI_CLI");
 
-        claudeCode.ifPresent(v -> {
-            buildScan.tag("AI");
-            buildScan.value("AI agent", "Claude Code");
-        });
-        if (codexSandbox.isPresent() || codexThreadId.isPresent()) {
-            buildScan.tag("AI");
-            buildScan.value("AI agent", "Codex");
-        }
-        openCode.ifPresent(v -> {
-            buildScan.tag("AI");
-            buildScan.value("AI agent", "OpenCode");
-        });
-        gemini.ifPresent(v -> {
-            buildScan.tag("AI");
-            buildScan.value("AI agent", "Gemini CLI");
+            claudeCode.ifPresent(v -> {
+                buildScan.tag("AI");
+                buildScan.value("AI agent", "Claude Code");
+            });
+            if (codexSandbox.isPresent() || codexThreadId.isPresent()) {
+                buildScan.tag("AI");
+                buildScan.value("AI agent", "Codex");
+            }
+            openCode.ifPresent(v -> {
+                buildScan.tag("AI");
+                buildScan.value("AI agent", "OpenCode");
+            });
+            gemini.ifPresent(v -> {
+                buildScan.tag("AI");
+                buildScan.value("AI agent", "Gemini CLI");
+            });
         });
     }
 


### PR DESCRIPTION
Reimplements gradle/common-custom-user-data-gradle-plugin#514 for the Maven extension, keeping the two tools symmetric.

The AI agent environment variables were read eagerly while applying the build scan enhancements. This moves the capture into a buildFinished action. The Maven extension has no configuration cache, so here this is purely an implementation detail rather than a fix, which is why there is no changelog entry. The build scan tags and values are unchanged.