### PR TITLE
Capture Cursor as an AI agent

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-- [NEW] TBD
+- [NEW] Capture Cursor as an AI agent via the `CURSOR_AGENT` environment variable

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -525,6 +525,7 @@ final class CustomBuildScanEnhancements {
         // This is best effort detection until something more official is implemented by Codex.
         Optional<String> codexSandbox = envVariable("CODEX_SANDBOX_NETWORK_DISABLED");
         Optional<String> codexThreadId = envVariable("CODEX_THREAD_ID");
+        Optional<String> cursor = envVariable("CURSOR_AGENT");
         Optional<String> openCode = envVariable("OPENCODE");
         Optional<String> gemini = envVariable("GEMINI_CLI");
 
@@ -536,6 +537,10 @@ final class CustomBuildScanEnhancements {
             buildScan.tag("AI");
             buildScan.value("AI agent", "Codex");
         }
+        cursor.ifPresent(v -> {
+            buildScan.tag("AI");
+            buildScan.value("AI agent", "Cursor");
+        });
         openCode.ifPresent(v -> {
             buildScan.tag("AI");
             buildScan.value("AI agent", "OpenCode");


### PR DESCRIPTION
Reimplements gradle/common-custom-user-data-gradle-plugin#517 for the Maven extension.

Detects Cursor via the `CURSOR_AGENT` environment variable and tags the build scan with `AI` and `AI agent = Cursor`, matching the existing Claude Code, Codex, OpenCode, and Gemini CLI detection.

The source PR's Gemini-in-Android-Studio detection via `ANDROID_STUDIO_AGENT` is not ported. The Maven extension has no Android Studio agent detection to extend, and Android Studio is a Gradle/Android-only concept here.

The source PR holds the detailed rationale and the variable sources.