### PR TITLE
Replace stale gradle.com references with develocity.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ captured and under which conditions.
 You can apply additional configuration beyond what is contributed by the Common Custom User Data Maven extension by default.
 The extension evaluates Groovy scripts from two locations:
 
-1. Any `*.groovy` files in the `custom-user-data` directory, located within the [Develocity storage directory](https://docs.gradle.com/develocity/maven/current/maven-extension/#anatomy-of-the-develocity-directory), `${user.home}/.m2/.develocity` by default
+1. Any `*.groovy` files in the `custom-user-data` directory, located within the [Develocity storage directory](https://docs.develocity.ai/maven/current/maven-extension/#anatomy-of-the-develocity-directory), `${user.home}/.m2/.develocity` by default
 2. A `.mvn/develocity-custom-user-data.groovy` or `.mvn/gradle-enterprise-custom-user-data.groovy` in your root project
 
 All matching files are evaluated with the following bindings:
@@ -88,7 +88,7 @@ This approach has a number of benefits:
 If your customized extension provides all required Develocity configuration, then a consumer project will get all the benefits of Develocity simply by applying the extension. The
 project sources provide a good template to get started with your own extension.
 
-Refer to the [Javadoc](https://docs.gradle.com/enterprise/maven-extension/api/) for more details on the key types available for use.
+Refer to the [Javadoc](https://docs.develocity.ai/maven/current/javadoc/) for more details on the key types available for use.
 
 ## Changelog
 
@@ -130,5 +130,5 @@ The Develocity Common Custom User Data Maven extension is open-source software r
 [develocity-build-validation-scripts]: https://github.com/gradle/develocity-build-validation-scripts
 [develocity-oss-projects]: https://github.com/gradle/develocity-oss-projects
 [quarkus-build-caching-extension]: https://github.com/gradle/quarkus-build-caching-extension
-[develocity]: https://gradle.com/develocity
+[develocity]: https://develocity.ai/
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/README.md
+++ b/README.md
@@ -130,5 +130,5 @@ The Develocity Common Custom User Data Maven extension is open-source software r
 [develocity-build-validation-scripts]: https://github.com/gradle/develocity-build-validation-scripts
 [develocity-oss-projects]: https://github.com/gradle/develocity-oss-projects
 [quarkus-build-caching-extension]: https://github.com/gradle/quarkus-build-caching-extension
-[develocity]: https://develocity.ai/
+[develocity]: https://develocity.ai
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <distributionManagement>
         <site>
             <id>Documentation</id>
-            <url>https://docs.develocity.ai/</url>
+            <url>https://docs.develocity.ai</url>
         </site>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <distributionManagement>
         <site>
             <id>Documentation</id>
-            <url>https://docs.gradle.com</url>
+            <url>https://docs.develocity.ai/</url>
         </site>
     </distributionManagement>
 
@@ -38,7 +38,7 @@
         <developer>
             <name>The Gradle team</name>
             <organization>Gradle Inc.</organization>
-            <organizationUrl>https://gradle.com</organizationUrl>
+            <organizationUrl>https://develocity.ai</organizationUrl>
         </developer>
     </developers>
 


### PR DESCRIPTION
Updates stale `gradle.com` references to their current canonical destinations. `gradle.com` and `docs.gradle.com` URLs now redirect to `develocity.ai` / `docs.develocity.ai`; this updates them to the canonical hosts.

**Changes**
- `README.md`: Develocity storage-directory doc link → `docs.develocity.ai/maven/current/maven-extension/#anatomy-of-the-develocity-directory`; Javadoc → `docs.develocity.ai/maven/current/javadoc/`; `[develocity]` → `develocity.ai/`
- `pom.xml`: `<url>` → `https://docs.develocity.ai/`; `<organizationUrl>` → `https://develocity.ai`

**Deliberately left unchanged**
- `.mvn/develocity.xml` / POM `xsi:schemaLocation` on `www.gradle.com` (e.g. `https://www.gradle.com/develocity-maven`, `.../schema/develocity-maven.xsd`): the current Develocity Maven extension docs still use exactly these — the XML namespace is a stable identifier, not a live URL, so it must stay.
