### PR TITLE
Detect GitHub Copilot as an AI agent

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,1 @@
-- [NEW] TBD
+- [NEW] Detect Copilot via the `COPILOT_CLI` and `COPILOT_AGENT` environment variables, capturing the `AI` tag and `AI agent` value `Copilot`

--- a/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -528,6 +528,8 @@ final class CustomBuildScanEnhancements {
         Optional<String> cursor = envVariable("CURSOR_AGENT");
         Optional<String> openCode = envVariable("OPENCODE");
         Optional<String> gemini = envVariable("GEMINI_CLI");
+        Optional<String> copilotCli = envVariable("COPILOT_CLI");
+        Optional<String> copilotAgent = envVariable("COPILOT_AGENT");
 
         claudeCode.ifPresent(v -> {
             buildScan.tag("AI");
@@ -549,6 +551,10 @@ final class CustomBuildScanEnhancements {
             buildScan.tag("AI");
             buildScan.value("AI agent", "Gemini CLI");
         });
+        if (copilotCli.isPresent() || copilotAgent.isPresent()) {
+            buildScan.tag("AI");
+            buildScan.value("AI agent", "Copilot");
+        }
     }
 
     private static void addCustomValueAndSearchLink(BuildScanApiAdapter buildScan, String name, String value) {


### PR DESCRIPTION
Reimplements gradle/common-custom-user-data-gradle-plugin#532 and gradle/common-custom-user-data-gradle-plugin#533 (merged there as one net change) for the Maven extension.

Captures the `AI` tag and `AI agent` value `Copilot` when either `COPILOT_CLI` or `COPILOT_AGENT` is present, matching the existing detection for Claude Code, Codex, Cursor, OpenCode, and Gemini CLI. A single `Copilot` value covers both surfaces, since the existing IDE detection already tags `Cmd Line` for the CLI and `VS Code` for the in-editor agent.

The Gradle PRs hold the detailed rationale and the manual verification scans.

Not ported: the Gradle-only `Provider` plumbing and the execution-time deferral that keeps agent metadata out of the configuration cache — the Maven extension reads these values eagerly and has no configuration cache.